### PR TITLE
minipeg48 を3機種目として追加

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,4 +44,5 @@ jobs:
           files: |
             output/windmill_technik.hex
             output/windmill_ymd40.hex
+            output/windmill_minipeg48.hex
           fail_on_unmatched_files: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,68 @@ IMEをかな入力にしていると通常の位置では打てない記号を�
 
 ---
 
+### 対応キーボードに minipeg48 を追加
+
+移植元だった [minipeg48](https://github.com/ChrisChrisLoLo/minipeg48)
+(Pro Micro互換の4x12オーソリニア) 自体を3機種目として取り込んだ。
+定義とキーマップは
+[cognitom/qmk_firmware_geonix41](https://github.com/cognitom/qmk_firmware_geonix41/tree/geonix41-customized-layout/keyboards/geonix41/minipeg48)
+から持ってきたもので、本家QMKには収録されていない。
+
+    technik / ymd40 / minipeg48
+
+キー配列は3機種とも同一。minipeg48 だけの差分は以下。
+
+#### LED非搭載
+
+`windmill.h` に `WINDMILL_LED_ENABLE` を導入し、LEDが載っている機種
+(`RGB_MATRIX_ENABLE` または `RGBLIGHT_ENABLE`) でのみ配色処理をコンパイルする
+ようにした。従来は `apply_keycolors()` の内側だけが `#ifdef RGB_MATRIX_ENABLE` で
+分岐していて、`extern const uint8_t lighting_map[]` や `cache_keycolors()` の
+呼び出しは無条件だったため、LED非搭載機ではリンクが通らなかった。
+
+これに伴い minipeg48 では以下が丸ごと外れる。
+
+- 配色エンジン一式 (`cache_keycolors` / `refresh_keycolors` / `apply_keycolors` /
+  `toggle_darkmode` / 消灯タイムアウト)
+- `layer_state_set_kb()` / `default_layer_state_set_kb()` (塗り直し専用のため)
+- `keymap.c` 側の `colorset[][6]` と `windmill_process_keycolor_user()`
+- `lighting_map[]` (= `minipeg48.c` そのものが不要)
+- `cached_keycolormap[4][48]` + `cached_keycolors[48]` の 240 バイトのRAM
+
+`MY_DARK` (明るさ 強/弱) はレイヤー3に置いていない。ただし
+`enum windmill_keycodes` には3機種共通で残してある (キーコードの値をずらさないため)。
+`windmill_config_t` の `led_darkmode` ビットも、EEPROMのレイアウトを揃えるため残した。
+
+#### レイヤー3の上段
+
+| | technik / ymd40 | minipeg48 |
+|--|--|--|
+| 11列目 | `QK_BOOT` | `QK_BOOT` |
+| 12列目 | `MY_DARK` | (なし) |
+
+移植元にはそもそも `QK_BOOT` が無かったが、他の2機種に揃えて同じ位置に置いた。
+
+#### `keyboard.json`
+
+移植元からの変更点:
+
+- **`tapping.term` / `tapping.hold_on_other_key_press` を明記した**。移植元は Vial の
+  QMK Settings のデフォルトに頼っていて `tapping` セクションが無かった。これがないと
+  親指Shiftや `LT()` の挙動が他の2機種とずれる
+- `mousekey` / `nkro` を無効化して technik / ymd40 と揃えた
+- `community_layouts: ["ortho_4x12"]` を追加
+- USB (`0xBEAF` / `0x0004`)、マトリクスピン、`LAYOUT_ortho_4x12` は移植元のまま
+
+#### Vialキーマップは持ち込んでいない
+
+移植元では `keymaps/vial` (`VIAL_ENABLE`) が主なビルド対象だったが、これは
+Vial-QMK フォークでないとビルドできず、このリポジトリの Docker (素の QMK 0.33.11) では
+通らない。`default` のみを移植した。Vial版が必要になったら、Vial-QMK 側に
+`keyboards/windmill` を置いて `keymaps/vial` を足す形になる。
+
+---
+
 ### リポジトリ構成
 
 #### `keyboard.json` への統合
@@ -232,6 +294,10 @@ firmware/
     readme.md                       qmk lint --strict が要求する
     keymaps/default/keymap.c        keymaps[] + colorset[] + 配色の分類
   ymd40/                            (同構成)
+  minipeg48/
+    keyboard.json
+    readme.md
+    keymaps/default/keymap.c        keymaps[] のみ (LED非搭載なので配色なし)
 ```
 
 - **ymd40 の独自定義を残した理由**: 本家QMKの `ymdk/ymd40/v2` は RGB が 8灯の想定だが、
@@ -263,7 +329,8 @@ tap-hold へ移行した以上これを残すと `LT`/`MT` が全く効かなく
   `windmill-qmk` 固定だったので、バージョンを上げてもイメージが作り直されなかった。
   現行QMKで未使用の `ALT_GET_KEYBOARDS` を削除
 - `entrypoint.sh`: `set -euo pipefail` を追加。以前はビルドが失敗しても `mv` に進んで
-  終了コード0で終わっていた。あわせてビルド前に `qmk lint --strict` を走らせるようにした
+  終了コード0で終わっていた。あわせてビルド前に `qmk lint --strict` を走らせるようにした。
+  ビルド対象は `technik ymd40 minipeg48` の3機種
 
 #### `.github/workflows/main.yml`
 
@@ -279,7 +346,7 @@ tap-hold へ移行した以上これを残すと `LT`/`MT` が全く効かなく
 
 | 旧 | 新 |
 |--|--|
-| `windmill.hex` (technikのみ) | `windmill_technik.hex` / `windmill_ymd40.hex` |
+| `windmill.hex` (technikのみ) | `windmill_technik.hex` / `windmill_ymd40.hex` / `windmill_minipeg48.hex` |
 
 ---
 
@@ -289,31 +356,38 @@ QMK 0.33.11 + avr-gcc 7.3 でビルド。警告なし、`qmk lint --strict` 通�
 
 | | Flash | RAM |
 |--|--|--|
-| technik | 16598 / 28672 (57%) | 1103 / 2560 (43%) |
-| ymd40 | 17400 / 28672 (60%) | 844 / 2560 (33%) |
+| technik | 16622 / 28672 (57%) | 1103 / 2560 (43%) |
+| ymd40 | 17422 / 28672 (60%) | 844 / 2560 (33%) |
+| minipeg48 | 13090 / 28672 (45%) | 331 / 2560 (12%) |
 
 配色の分類については、`keymap.c` から分類関数とキーマップを機械的に抜き出して
 ホスト側で全192キー分を評価し、意図したカテゴリになることを確認した。
 
-**実機での確認は未実施。** 以下は要確認:
+`WINDMILL_LED_ENABLE` の導入では、technik / ymd40 のFlash・RAMともに導入前と
+1バイトも変わっていないこと、上記の配色チェックの出力が完全一致することを確認している。
 
-- かな⇔英数 の切り替えと、それに追従するLEDの色替え
-- `MY_DARK` の明暗トグルと、USB挿し直し後の保持
-- 親指Shift (tap=B/N, hold=Shift, Shift中のtap=半角スペース)
-- かなモードでSymレイヤーの数字・記号が全角にならないか (`LT2_IME_WAIT_MS` の調整)
-- `MY_WIN` / `MY_ANDR` による 「」 の出し分け
+実機での確認状況:
+
+| | |
+|--|--|
+| かな⇔英数 の切り替えと、それに追従するLEDの色替え | 確認済み (かなレイヤーの配色は後述の修正あり) |
+| `MY_DARK` の明暗トグルと、USB挿し直し後の保持 | 確認済み |
+| 親指Shift (tap=B/N, hold=Shift, Shift中のtap=半角スペース) | 確認済み |
+| かなモードでSymレイヤーの数字・記号が全角にならないか | 確認済み |
+| `MY_WIN` / `MY_ANDR` による 「」 の出し分け | 未確認 |
+| **minipeg48** | **未確認** |
 
 ---
 
 ### ドキュメントについて
 
-**`README.md` と `docs/` 配下は v2.0.2 のままで、上記の変更が反映されていない。**
-旧かな配列、ローマ字かなエミュレーション、IME種別5種、Mod Seq / Quick Tap、
-`windmill_tap_code()` など、既に存在しない機能の説明が残っている。
-リリース資産名も `windmill.hex` のままになっている。
+`README.md` と `docs/` 配下は、上記の変更に合わせて作者が更新済み
+(旧い内容は `docs/archived/` へ移動)。
 
-`docs/images/layout-main.png` / `docs/images/layout-kana.png` も旧かな配列の図で、
-現在のキーマップとは一致しない。
+**未反映なのは minipeg48 の追加分のみ。** `README.md` の「対応キーボード」が
+Technik と YMD40 の2つのままなので、必要であれば
+[minipeg48](https://github.com/ChrisChrisLoLo/minipeg48) を足すこと
+(市販品ではなく、PCBを自作するタイプ)。
 
 Androidで使う場合の注意 (移植元の readme より):
 

--- a/firmware/minipeg48/keyboard.json
+++ b/firmware/minipeg48/keyboard.json
@@ -1,0 +1,90 @@
+{
+    "keyboard_name": "minipeg48",
+    "manufacturer": "sporewoh",
+    "maintainer": "cognitom",
+    "url": "https://github.com/cognitom/windmill",
+    "usb": {
+        "vid": "0xBEAF",
+        "pid": "0x0004",
+        "device_version": "0.0.1"
+    },
+    "processor": "atmega32u4",
+    "bootloader": "atmel-dfu",
+    "matrix_pins": {
+        "cols": ["B5", "B4", "D6", "D7", "D4", "D5", "D3", "D2", "D1", "D0", "B6", "C6"],
+        "rows": ["F0", "F1", "F4", "F5"]
+    },
+    "diode_direction": "COL2ROW",
+    "features": {
+        "bootmagic": true,
+        "extrakey": true,
+        "audio": false,
+        "backlight": false,
+        "mousekey": false,
+        "nkro": false,
+        "rgb_matrix": false,
+        "rgblight": false
+    },
+    "build": {
+        "lto": true
+    },
+    "tapping": {
+        "term": 200,
+        "hold_on_other_key_press": true
+    },
+    "community_layouts": ["ortho_4x12"],
+    "layouts": {
+        "LAYOUT_ortho_4x12": {
+            "layout": [
+                {"matrix": [0, 0], "x": 0, "y": 0},
+                {"matrix": [0, 1], "x": 1, "y": 0},
+                {"matrix": [0, 2], "x": 2, "y": 0},
+                {"matrix": [0, 3], "x": 3, "y": 0},
+                {"matrix": [0, 4], "x": 4, "y": 0},
+                {"matrix": [0, 5], "x": 5, "y": 0},
+                {"matrix": [0, 6], "x": 6, "y": 0},
+                {"matrix": [0, 7], "x": 7, "y": 0},
+                {"matrix": [0, 8], "x": 8, "y": 0},
+                {"matrix": [0, 9], "x": 9, "y": 0},
+                {"matrix": [0, 10], "x": 10, "y": 0},
+                {"matrix": [0, 11], "x": 11, "y": 0},
+                {"matrix": [1, 0], "x": 0, "y": 1},
+                {"matrix": [1, 1], "x": 1, "y": 1},
+                {"matrix": [1, 2], "x": 2, "y": 1},
+                {"matrix": [1, 3], "x": 3, "y": 1},
+                {"matrix": [1, 4], "x": 4, "y": 1},
+                {"matrix": [1, 5], "x": 5, "y": 1},
+                {"matrix": [1, 6], "x": 6, "y": 1},
+                {"matrix": [1, 7], "x": 7, "y": 1},
+                {"matrix": [1, 8], "x": 8, "y": 1},
+                {"matrix": [1, 9], "x": 9, "y": 1},
+                {"matrix": [1, 10], "x": 10, "y": 1},
+                {"matrix": [1, 11], "x": 11, "y": 1},
+                {"matrix": [2, 0], "x": 0, "y": 2},
+                {"matrix": [2, 1], "x": 1, "y": 2},
+                {"matrix": [2, 2], "x": 2, "y": 2},
+                {"matrix": [2, 3], "x": 3, "y": 2},
+                {"matrix": [2, 4], "x": 4, "y": 2},
+                {"matrix": [2, 5], "x": 5, "y": 2},
+                {"matrix": [2, 6], "x": 6, "y": 2},
+                {"matrix": [2, 7], "x": 7, "y": 2},
+                {"matrix": [2, 8], "x": 8, "y": 2},
+                {"matrix": [2, 9], "x": 9, "y": 2},
+                {"matrix": [2, 10], "x": 10, "y": 2},
+                {"matrix": [2, 11], "x": 11, "y": 2},
+                {"matrix": [3, 0], "x": 0, "y": 3},
+                {"matrix": [3, 1], "x": 1, "y": 3},
+                {"matrix": [3, 2], "x": 2, "y": 3},
+                {"matrix": [3, 3], "x": 3, "y": 3},
+                {"matrix": [3, 4], "x": 4, "y": 3},
+                {"matrix": [3, 5], "x": 5, "y": 3},
+                {"matrix": [3, 6], "x": 6, "y": 3},
+                {"matrix": [3, 7], "x": 7, "y": 3},
+                {"matrix": [3, 8], "x": 8, "y": 3},
+                {"matrix": [3, 9], "x": 9, "y": 3},
+                {"matrix": [3, 10], "x": 10, "y": 3},
+                {"matrix": [3, 11], "x": 11, "y": 3}
+            ]
+        }
+    }
+}

--- a/firmware/minipeg48/keymaps/default/keymap.c
+++ b/firmware/minipeg48/keymaps/default/keymap.c
@@ -1,0 +1,54 @@
+/* Copyright 2021-2026 Tsutomu Kawamura
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "windmill.h"
+
+/* レイヤー0(かな)とレイヤー1(英数)がベースレイヤーで、MY_LCTL のタップ/
+ * ダブルタップで切り替わる。レイヤー1で透過のキーはレイヤー0へ落ちる。
+ *
+ * technik / ymd40 と同じ配列。LED非搭載なので MY_DARK だけ置いていない。 */
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [LAYER_KANA] = LAYOUT_ortho_4x12(
+    KC_ESC,  KC_1,         KC_2,         KC_3,        KC_4,        KC_5,          KC_6,          KC_7,        KC_8,           KC_9,    KC_0,    KC_ENT,
+    KC_TAB,  KC_Q,         MY_W,         KC_E,        MY_R,        KC_T,          KC_Y,          MY_U,        KC_I,           MY_O,    MY_P,    MY_LBRC,
+    KC_BSPC, MY_A,         KC_S,         KC_D,        KC_F,        KC_G,          KC_H,          KC_J,        MY_K,           MY_L,    MY_SCLN, MY_QUOT,
+    MY_LCTL, LGUI_T(KC_Z), LALT_T(KC_X), LT(3,KC_C),  LT(2,KC_V),  LSFT_T(KC_B),  RSFT_T(KC_N),  LT(2,KC_M),  LT(3,KC_COMMA), KC_DOT,  KC_SLSH, KC_GRV
+  ),
+
+  [LAYER_ALPHA] = LAYOUT_ortho_4x12(
+    _______, KC_Q,         KC_W,         KC_E,        KC_R,        KC_T,          KC_Y,          KC_U,        KC_I,           KC_O,    KC_P,    _______,
+    _______, KC_A,         KC_S,         KC_D,        KC_F,        KC_G,          KC_H,          KC_J,        KC_K,           KC_L,    KC_SCLN, KC_QUOT,
+    _______, KC_Z,         KC_X,         KC_C,        KC_V,        KC_B,          KC_N,          KC_M,        KC_COMM,        KC_DOT,  KC_UP,   KC_RGHT,
+    _______, KC_LGUI,      KC_LALT,      MO(3),       LT(2,KC_BSLS), LSFT_T(KC_SPC), LSFT_T(KC_SPC), LT(2,KC_SLSH), MO(3),    KC_APP,  KC_LEFT, KC_DOWN
+  ),
+
+  [LAYER_SYM] = LAYOUT_ortho_4x12(
+    _______, KC_1,         KC_2,         KC_3,        KC_4,        KC_5,          KC_6,          KC_7,        KC_8,           KC_9,    KC_0,    _______,
+    _______, S(KC_1),      S(KC_2),      S(KC_3),     S(KC_4),     S(KC_5),       S(KC_6),       S(KC_7),     S(KC_8),        S(KC_9), S(KC_0), KC_GRV,
+    _______, KC_EQL,       S(KC_EQL),    KC_MINS,     S(KC_MINS),  KC_LBRC,       KC_RBRC,       S(KC_GRV),   S(KC_LBRC),     S(KC_RBRC), KC_UP, KC_RGHT,
+    _______, _______,      _______,      _______,     _______,     S(KC_BSLS),    S(KC_SLSH),    _______,     _______,        _______, KC_LEFT, KC_DOWN
+  ),
+
+  [LAYER_FN] = LAYOUT_ortho_4x12(
+    MY_WIN,  KC_NO,        KC_NO,        MY_ANDR,     KC_NO,       KC_NO,         KC_NO,         KC_NO,       KC_NO,          KC_NO,   QK_BOOT, KC_NO,
+    KC_F1,   KC_F2,        KC_F3,        KC_F4,       KC_F5,       KC_F6,         KC_F7,         KC_F8,       KC_F9,          KC_F10,  KC_F11,  KC_F12,
+    KC_DEL,  KC_PSCR,      KC_NO,        KC_NO,       KC_NO,       KC_BRID,       KC_BRIU,       KC_MUTE,     KC_VOLD,        KC_VOLU, KC_UP,   KC_RGHT,
+    _______, _______,      _______,      _______,     _______,     _______,       _______,       _______,     _______,        _______, KC_LEFT, KC_DOWN
+  ),
+
+};

--- a/firmware/minipeg48/readme.md
+++ b/firmware/minipeg48/readme.md
@@ -1,0 +1,24 @@
+# Windmill for minipeg48
+
+40%キーボード [sporewoh minipeg48](https://github.com/ChrisChrisLoLo/minipeg48)
+(Pro Micro互換・4x12オーソリニア) 向けの Windmill キーマップ。
+キー処理は親フォルダの `windmill.c` を参照。
+
+* MCU: atmega32u4 / ブートローダ: atmel-dfu
+* LED: なし
+
+LED非搭載なので `windmill.c` の配色処理は `WINDMILL_LED_ENABLE` によって
+コンパイルから外れる。あわせて、レイヤー3の `MY_DARK` (明るさ 強/弱) も置いていない。
+
+キーボード定義は
+[cognitom/qmk_firmware_geonix41](https://github.com/cognitom/qmk_firmware_geonix41/tree/geonix41-customized-layout/keyboards/geonix41/minipeg48)
+から持ってきたもの。本家QMKには収録されていない。
+
+ビルド:
+
+    make windmill/minipeg48:default
+
+書き込み (Escキー = マトリクス(0,0) を押しながらUSB接続でブートローダ起動。
+効かない場合はPCB裏のリセットボタン。レイヤー3の `QK_BOOT` でも入れる):
+
+    make windmill/minipeg48:default:flash

--- a/firmware/windmill.c
+++ b/firmware/windmill.c
@@ -20,7 +20,9 @@
  * default_layer_set を使う。かな入力はOS側のIMEに任せる (レイヤー0が素の
  * QWERTY+数字段で、標準のJISかな配置になる)。
  *
- * LEDはキーコードの種類ごとに色を割り当てる独自実装で、こちらは従来のまま。 */
+ * LEDはキーコードの種類ごとに色を割り当てる独自実装で、こちらは従来のまま。
+ * LED非搭載機 (minipeg48) では WINDMILL_LED_ENABLE が立たず、配色処理は
+ * 丸ごとコンパイルから外れる。 */
 
 #include "windmill.h"
 
@@ -30,7 +32,7 @@ typedef union {
     uint32_t raw;
     struct {
         bool is_android : 1;   // MY_O/MY_P のShift時出力をAndroid向けにする
-        bool led_darkmode : 1; // LEDを暗いほうの配色にする
+        bool led_darkmode : 1; // LEDを暗いほうの配色にする (LED非搭載機では未使用)
     };
 } windmill_config_t;
 static windmill_config_t windmill_config;
@@ -38,6 +40,8 @@ static windmill_config_t windmill_config;
 /*
  * RGB Matrix / Light
  */
+
+#ifdef WINDMILL_LED_ENABLE
 
 #define RGBMATRIX_TIMEOUT 10 // 分
 #define CL_TRANS 0xFF        // 透過キー。下位レイヤーの色を使う
@@ -167,6 +171,8 @@ static bool process_led_timeout(uint16_t keycode, keyrecord_t *record) {
     refresh_led_timeout();
     return !was_off;
 }
+
+#endif // WINDMILL_LED_ENABLE
 
 /*
  * MY_LCTL: tap = 英数, double-tap = かな, hold = Ctrl + 英数レイヤー
@@ -342,7 +348,9 @@ bool pre_process_record_kb(uint16_t keycode, keyrecord_t *record) {
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+#ifdef WINDMILL_LED_ENABLE
     if (!process_led_timeout(keycode, record)) return false;
+#endif
     if (!process_record_user(keycode, record)) return false;
 
     // 親指Shift以外のキー押下でダーティ化
@@ -366,11 +374,13 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
     }
 
     switch (keycode) {
+#ifdef WINDMILL_LED_ENABLE
         case MY_DARK: // LEDの明るさ 強/弱
             if (record->event.pressed) {
                 toggle_darkmode();
             }
             return false;
+#endif
 
         case MY_WIN:
             if (record->event.pressed) {
@@ -427,7 +437,9 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 }
 
 void matrix_scan_kb(void) {
+#ifdef WINDMILL_LED_ENABLE
     update_led_timeout();
+#endif
 
     if (td_phase == TD_PRESSED && !td_hold_active && timer_elapsed(td_timer) > TD_TERM) {
         td_hold_on();
@@ -443,24 +455,30 @@ void matrix_scan_kb(void) {
 void keyboard_post_init_kb(void) {
     windmill_config.raw = eeconfig_read_kb();
     is_android          = windmill_config.is_android;
-    led_darkmode        = windmill_config.led_darkmode;
+#ifdef WINDMILL_LED_ENABLE
+    led_darkmode = windmill_config.led_darkmode;
+#endif
 
     // keymap.c 側で windmill_init_keycolors() を呼ぶので、配色を組む前に済ませる
     keyboard_post_init_user();
 
-#ifdef RGB_MATRIX_ENABLE
+#ifdef WINDMILL_LED_ENABLE
+#    ifdef RGB_MATRIX_ENABLE
     rgb_matrix_mode_noeeprom(RGB_MATRIX_NONE); // アニメーションなし。全て自前で描く
     rgb_matrix_sethsv_noeeprom(HSV_OFF);
-#elif defined(RGBLIGHT_ENABLE)
+#    elif defined(RGBLIGHT_ENABLE)
     rgblight_enable_noeeprom();
     rgblight_mode_noeeprom(RGBLIGHT_MODE_STATIC_LIGHT);
     rgblight_sethsv_noeeprom(HSV_OFF);
-#endif
+#    endif
 
     cache_keycolors();
     led_initialized = true;
     refresh_keycolors(layer_state, default_layer_state);
+#endif // WINDMILL_LED_ENABLE
 }
+
+#ifdef WINDMILL_LED_ENABLE
 
 layer_state_t layer_state_set_kb(layer_state_t state) {
     state = layer_state_set_user(state);
@@ -475,7 +493,7 @@ layer_state_t default_layer_state_set_kb(layer_state_t state) {
     return state;
 }
 
-#ifdef RGB_MATRIX_ENABLE
+#    ifdef RGB_MATRIX_ENABLE
 bool rgb_matrix_indicators_kb(void) {
     if (!rgb_matrix_indicators_user()) return false;
     if (!led_on || !led_initialized) return true;
@@ -483,4 +501,6 @@ bool rgb_matrix_indicators_kb(void) {
     apply_keycolors();
     return true;
 }
-#endif
+#    endif
+
+#endif // WINDMILL_LED_ENABLE

--- a/firmware/windmill.h
+++ b/firmware/windmill.h
@@ -18,6 +18,11 @@
 
 #include "quantum.h"
 
+/* LEDの配色処理を持つかどうか。minipeg48 はLED非搭載なので丸ごと外れる */
+#if defined(RGB_MATRIX_ENABLE) || defined(RGBLIGHT_ENABLE)
+#    define WINDMILL_LED_ENABLE
+#endif
+
 /* レイヤー番号。keymaps[] の並びと一致させること */
 #define LAYER_KANA  0 // かな。OS側のIMEを「かな入力」にして使う
 #define LAYER_ALPHA 1 // 英数
@@ -47,8 +52,10 @@ enum windmill_keycodes {
     MY_A,           // Shift時: Z
     MY_WIN,         // MY_O/MY_PのShift時出力をWindows/デスクトップ向けに (EEPROM保存)
     MY_ANDR,        // MY_O/MY_PのShift時出力をAndroid向けに (EEPROM保存)
-    MY_DARK,        // LEDの明るさ 強/弱 を切り替え (EEPROM保存)
+    MY_DARK,        // LEDの明るさ 強/弱 を切り替え (EEPROM保存。LED搭載機のみ)
 };
+
+#ifdef WINDMILL_LED_ENABLE
 
 /* keymap.c 側で定義する配色テーブルを登録する。
  * colorset は [色][6] = {明るい時のR,G,B, 暗い時のR,G,B} の配列。 */
@@ -62,3 +69,5 @@ uint8_t windmill_process_keycolor_user(uint8_t layer, uint16_t keycode);
 
 /* MT()/LT() をタップ側のキーコードに展開する。それ以外はそのまま返す。 */
 uint16_t windmill_base_keycode(uint16_t keycode);
+
+#endif // WINDMILL_LED_ENABLE

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 host_uid=$(ls -n "$0" | awk '{print $3}') # study who my owner is
 host_gid=$(ls -n "$0" | awk '{print $4}') # study what I belong to
 
-for keyboard in technik ymd40; do
+for keyboard in technik ymd40 minipeg48; do
   qmk lint -kb "windmill/$keyboard" -km default --strict
   make "windmill/$keyboard:default"
   mv "windmill_${keyboard}_default.hex" "/output/windmill_${keyboard}.hex"


### PR DESCRIPTION
移植元だった geonix41/minipeg48 (ChrisChrisLoLo/minipeg48) 自体を、technik / ymd40 に続く3機種目として取り込みました。キー配列は3機種とも同一です。

## 変更点

### minipeg48 の追加

- `firmware/minipeg48/keyboard.json`
- `firmware/minipeg48/keymaps/default/keymap.c`
- `firmware/minipeg48/readme.md`

keyboard.json は移植元をベースに、`tapping.term` / `hold_on_other_key_press` を明記しました (移植元は Vial の QMK Settings のデフォルトに頼っていた)。mousekey / nkro は他の2機種に揃えて無効化しています。Vial版キーマップは Vial-QMK が必要なため持ち込んでいません。

### `WINDMILL_LED_ENABLE` の導入

minipeg48 はLED非搭載なので、`firmware/windmill.h` に `WINDMILL_LED_ENABLE` を導入し、LED搭載機でのみ配色処理をコンパイルするようにしました。

```c
#if defined(RGB_MATRIX_ENABLE) || defined(RGBLIGHT_ENABLE)
#    define WINDMILL_LED_ENABLE
#endif
```

従来は `apply_keycolors()` の内側だけが `RGB_MATRIX_ENABLE` で分岐していて、`lighting_map[]` の extern や `cache_keycolors()` の呼び出しは無条件だったため、LED非搭載機ではリンクが通りませんでした。technik は RGB Matrix、ymd40 は RGBLight とバックエンドが異なるため、「配色機能の有無」を表すこのフラグと「どのバックエンドか」の分岐を2段構えにしています。

これに伴い minipeg48 では、レイヤー3の `MY_DARK` (LEDの明るさ 強/弱) も置いていません。

### ビルド

`scripts/entrypoint.sh` と release ワークフロー (`windmill_minipeg48.hex`) に minipeg48 を追加しました。

## 確認したこと

3機種とも警告なしでビルドでき、`qmk lint --strict` を通過します。

| | Flash | RAM |
|--|--|--|
| technik | 16622 / 28672 (57%) | 1103 / 2560 (43%) |
| ymd40 | 17422 / 28672 (60%) | 844 / 2560 (33%) |
| minipeg48 | 13090 / 28672 (45%) | 331 / 2560 (12%) |

technik / ymd40 の Flash・RAM はいずれも `WINDMILL_LED_ENABLE` 導入前と1バイトも変わっていません。配色については `keymap.c` から分類関数とキーマップを機械的に抜き出してホスト側で全192キー分を評価し、導入前と出力が完全一致することを確認しています。

**実機での確認は未実施です。** minipeg48 の実機フラッシュと動作確認が残っています。

---
_Generated by [Claude Code](https://claude.ai/code/session_018xJYRsBQkEArea8CgkZwca)_