### PR TITLE
geonix41 を4機種目として追加

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,13 +16,23 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      # geonix41 のベンダーブロブ。リポジトリには置けないので毎回取りに行くが、
+      # 中身が変わるのは配布物が差し替わったときだけなのでキャッシュが効く。
+      # 落とすのは 97KB の2ファイルだけ (取得スクリプトのコメント参照)
+      - name: Cache vendor blob
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: rdr-lib-${{ hashFiles('scripts/fetch-vendor-blob.py') }}
       - name: Build firmware
         run: bash scripts/build.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: windmill-hex
-          path: output/*.hex
+          name: windmill-firmware
+          path: |
+            output/*.hex
+            output/*.bin
           if-no-files-found: error
 
   release:
@@ -36,7 +46,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: windmill-hex
+          name: windmill-firmware
           path: output
       - name: Create release
         uses: softprops/action-gh-release@v2
@@ -45,4 +55,5 @@ jobs:
             output/windmill_technik.hex
             output/windmill_ymd40.hex
             output/windmill_minipeg48.hex
+            output/windmill_geonix41.bin
           fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.hex
+*.bin
+
+# ベンダー配布物。scripts/fetch-vendor-blob.py が取ってくる (再配布しない)
+/vendor/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Windmill is a keymap for 40% keyboards.
 - [Boardsource Technik](https://boardsource.xyz/store/5ffb9b01edd0447f8023fdb2)
 - [YMD40](https://ymdkey.com/collections/40-mini-diy)
 - [Geonix48](https://chosfox.com/ja/products/chosfox-x-masro-geonix48) ※minipeg48相当
+- Geonix41 (REV.2.5 1U / USB・BLE×3・2.4G の三モード)
 
 ファームウェアのバイナリは[リリースページ](https://github.com/cognitom/windmill/releases)からダウンロードできます。
 
@@ -98,3 +99,9 @@ Copyright (c) 2021-2026 Tsutomu Kawamura
 - `technik`: QMKの [`boardsource/technik_o`](https://github.com/qmk/qmk_firmware/tree/master/keyboards/boardsource/technik_o)
 - `ymd40`: QMKの [`ymdk/ymd40/v2`](https://github.com/qmk/qmk_firmware/tree/master/keyboards/ymdk/ymd40) (LEDの数を実機に合わせて変更)
 - `minipeg48`: [sporewoh minipeg48](https://github.com/ChrisChrisLoLo/minipeg48) (本家QMKには未収録)
+- `geonix41`: ベンダー (RDMCTMZT) 配布のソースをもとに移植 (本家QMKには未収録)
+
+`geonix41` だけは無線・電源・LED制御にベンダー提供のクローズドソースなライブラリ
+(`librdrcommon.a`) を使っており、これはこのリポジトリには含まれていません。
+ビルド時に `scripts/fetch-vendor-blob.py` がベンダー配布物から取得します。
+詳しくは [firmware/geonix41/readme.md](firmware/geonix41/readme.md) を参照してください。

--- a/firmware/geonix41/chconf.h
+++ b/firmware/geonix41/chconf.h
@@ -1,0 +1,24 @@
+/* Copyright 2021 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define CH_CFG_ST_TIMEDELTA  0
+#define CH_CFG_ST_RESOLUTION 16
+
+#define CH_CFG_ST_FREQUENCY 1000
+
+#include_next <chconf.h>

--- a/firmware/geonix41/config.h
+++ b/firmware/geonix41/config.h
@@ -1,0 +1,78 @@
+/* Copyright 2023 Finalkey
+ * Copyright 2023 LiWenLiu <https://github.com/LiuLiuQMK>
+ * Copyright 2026 Tsutomu Kawamura
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/* rdr_lib が QK_KB_0 から30個の自前キーコード (Custom_Keycodes) を並べているので、
+ * windmill の MY_* はその後ろから始める。ズレの検知は geonix41.c の
+ * _Static_assert で行っている */
+#define WINDMILL_KEYCODE_BASE QK_KB_30
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+#define MATRIX_UNSELECT_DRIVE_HIGH
+#define CORTEX_ENABLE_WFI_IDLE          FALSE
+
+/* Ensure we jump to bootloader if the RESET keycode was pressed */
+#define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
+
+/* デバウンスドライバ側は未定義でも5にフォールバックするので qmk lint は
+ * 「デフォルトと同じ」と言ってくるが、消してはいけない。
+ * bootmagic.c は BOOTMAGIC_DEBOUNCE を DEBOUNCE*2 で作り、DEBOUNCE が
+ * 見えないときだけ 30 に落ちるため、消すと起動時の待ちが 10ms → 30ms に伸びる */
+#define DEBOUNCE 5
+
+/* tap-hold は別キーが押された時点でホールド確定。
+ * LGUI_T(KC_Z) や LT(2,KC_V) の打鍵感がこれで決まる */
+#define HOLD_ON_OTHER_KEY_PRESS
+
+/* rdr_lib のカスタムEEPROMドライバ用。rdr_common.h のバッファサイズにも
+ * 使われるので、減らすとブロブ側とズレる */
+#define EEPROM_SIZE 1152
+
+/* ベンダーの元の設定には EECONFIG_KB_DATA_SIZE 1 があったが外してある。
+ * QMK は EECONFIG_KB_DATA_SIZE が 0 のときだけ eeconfig_read_kb()/update_kb() を
+ * 生やすので (quantum/eeconfig.h)、1 のままだと windmill.c の設定保存が通らない。
+ * ブロブは QMK の eeconfig を eeconfig_disable() 以外使っておらず、自前のデータは
+ * 別のフラッシュ領域 (IAPROM) に置いているので外して問題ない。 */
+#define EECONFIG_USER_DATA_SIZE 4
+
+#ifndef NOP_FUDGE
+#define NOP_FUDGE 0.4
+#endif
+
+/* キー下 48個 (0〜47) + アンダーグロー 29個 (48〜76)。
+ * windmill が塗るのは lighting_map で指したキー下だけで、
+ * アンダーグローはベンダー実装 (User_Led_Show) に任せる */
+#define RGB_MATRIX_LED_COUNT 77
+#define RGB_MATRIX_KEYPRESSES
+#define RGB_MATRIX_KEYRELEASES
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#define RGB_DISABLE_AFTER_TIMEOUT 0
+#define RGB_MATRIX_MAXIMUM_BRIGHTNESS 144
+#define RGB_MATRIX_SPD_STEP 64
+
+/* windmill は post_init で RGB_MATRIX_NONE + HSV_OFF にしてから自前で描くので、
+ * ここはその前の初期状態にすぎない。背景を消しておく */
+#define RGB_MATRIX_DEFAULT_MODE RGB_MATRIX_SOLID_COLOR
+#define RGB_MATRIX_DEFAULT_SAT 0
+#define RGB_MATRIX_DEFAULT_VAL 0
+
+#define RGB_MATRIX_SLEEP

--- a/firmware/geonix41/geonix41.c
+++ b/firmware/geonix41/geonix41.c
@@ -1,0 +1,167 @@
+/* Copyright 2023 Finalkey
+ * Copyright 2023 LiWenLiu <https://github.com/LiuLiuQMK>
+ * Copyright 2026 Tsutomu Kawamura
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* geonix41 の機種固有部分。キーの処理は全て windmill.c 側にあるので、
+ * ここに残っているのはベンダーライブラリ (rdr_lib) との配線だけ。 */
+
+#include "windmill.h"
+#include "../../../lib/rdr_lib/rdr_common.h"
+
+/* rdr_lib 側の enum が増減して MY_* の値がズレたときに検知する番兵。
+ * ズレるとブロブが自分のキーコードとして MY_* を食ってしまう。 */
+_Static_assert((int)MY_O == (int)QMK_KB_BLE3_PAIR + 1,
+               "WINDMILL_KEYCODE_BASE が rdr_lib の Custom_Keycodes とぶつかっている");
+
+/* ブロブは VIA / RAW HID ありきでビルドされているので、それらを無効にした
+ * この構成では未定義参照になる。同等に振る舞うスタブで埋める。 */
+#if !defined(VIA_ENABLE)
+#    include "keymap_introspection.h"
+
+// BLEペアリングコード等の自動入力用。静的キーマップのレイヤー0から引く
+uint16_t dynamic_keymap_get_keycode(uint8_t layer, uint8_t row, uint8_t column) {
+    if (layer >= keymap_layer_count()) {
+        return KC_NO;
+    }
+    return keymap_key_to_keycode(layer, (keypos_t){.row = row, .col = column});
+}
+#endif
+
+#if !defined(RAW_ENABLE)
+// ベンダーツール向けの raw HID 送信。送り先がないので何もしない
+void raw_hid_send(uint8_t *data, uint8_t length) {
+    (void)data;
+    (void)length;
+}
+#endif
+
+/*
+ * キースキャン
+ */
+
+void matrix_io_delay(void) {}
+void matrix_output_select_delay(void) {}
+void matrix_output_unselect_delay(uint8_t line, bool key_pressed) {}
+
+/*
+ * LED
+ */
+
+/* キー下のLEDの位置。キーの並び (行×列) に対応する。
+ * 最下段だけ物理配置の都合で 42 が 2 番目に入る。48〜76 はアンダーグローで、
+ * windmill からは触らずベンダー実装に任せる。 */
+const uint8_t lighting_map[MATRIX_ROWS * MATRIX_COLS] = {
+     0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11,
+    12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+    24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+    36, 42, 37, 38, 39, 40, 41, 43, 44, 45, 46, 47
+};
+
+/* RGB Matrix の物理配置。ベンダーのLEDドライバが参照する */
+led_config_t g_led_config = { {
+    {  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11 },
+    { 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 },
+    { 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35 },
+    { 36, 42, 37, 38, 39, 40, 41, 43, 44, 45, 46, 47 }
+}, {
+    // キー下
+    {   0, 10}, {  20, 10}, {  40, 10}, {  60, 10}, {  80, 10}, { 100, 10},
+    { 120, 10}, { 140, 10}, { 160, 10}, { 180, 10}, { 200, 10}, { 224, 10},
+    {   0, 20}, {  20, 20}, {  40, 20}, {  60, 20}, {  80, 20}, { 100, 20},
+    { 120, 20}, { 140, 20}, { 160, 20}, { 180, 20}, { 200, 20}, { 224, 20},
+    {   0, 30}, {  20, 30}, {  40, 30}, {  60, 30}, {  80, 30}, { 100, 30},
+    { 120, 30}, { 140, 30}, { 160, 30}, { 180, 30}, { 200, 30}, { 224, 30},
+    {   0, 40}, {  20, 40}, {  40, 40}, {  60, 40}, {  80, 40}, { 100, 40},
+    { 120, 40}, { 140, 40}, { 160, 40}, { 180, 40}, { 200, 40}, { 224, 40},
+    // アンダーグロー
+    { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65},
+    { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65},
+    { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65},
+    { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65},
+    { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}, { 255, 65}
+}, {
+    // キー下
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    // アンダーグロー
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+} };
+
+/*
+ * 電源・スリープ
+ */
+
+static bool usb_enum_done = false;
+
+void notify_usb_device_state_change_user(struct usb_device_state usb_device_state) {
+    if (Keyboard_Info.Key_Mode == QMK_USB_MODE) {
+        if (usb_device_state.configure_state == USB_DEVICE_STATE_CONFIGURED) {
+            if (!usb_enum_done) { // 最初の CONFIGURED でだけ実行
+                Usb_If_Ok       = true;
+                Usb_If_Ok_Led   = true;
+                Usb_If_Ok_Delay = 0;
+                usb_enum_done   = true;
+            }
+        } else {
+            Usb_If_Ok     = false;
+            Usb_If_Ok_Led = false;
+            usb_enum_done = false; // 切断でリセット
+        }
+    } else {
+        Usb_If_Ok     = false;
+        Usb_If_Ok_Led = false;
+    }
+}
+
+void housekeeping_task_kb(void) {
+    User_Keyboard_Reset();
+    housekeeping_task_user();
+}
+
+void board_init(void) {
+    User_Keyboard_Init();
+}
+
+/*
+ * windmill の機種フック
+ */
+
+void windmill_board_post_init(void) {
+    User_Keyboard_Post_Init();
+}
+
+void windmill_board_led_begin(void) {
+    // ベンダー実装 (電池残量・ペアリング表示など) を先に描かせる。
+    // windmill の配色はこのあと上から塗られる
+    User_Led_Show();
+}
+
+/* スリープ抑止。MY_* のように windmill が途中で消費するキーでも効かせたいので、
+ * process_record ではなく pre_process 側で行う */
+void windmill_board_pre_process_record(uint16_t keycode, keyrecord_t *record) {
+    Usb_Change_Mode_Delay  = 0;
+    Usb_Change_Mode_Wakeup = false;
+}
+
+bool windmill_board_process_record(uint16_t keycode, keyrecord_t *record) {
+    // 無線モード切替など、ブロブ側のキーコードはここで処理される。
+    // windmill が消費した MY_* は元の実装でもここへは来ていない
+    return Key_Value_Dispose(keycode, record);
+}

--- a/firmware/geonix41/halconf.h
+++ b/firmware/geonix41/halconf.h
@@ -1,0 +1,29 @@
+/* Copyright 2021 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define HAL_USE_PWM TRUE
+
+#define ES32_PWM_USE_GP16C4T2   TRUE
+
+#define BACKLIGHT_PWM_DRIVER    PWM_GP16C4T2
+#define BACKLIGHT_PWM_CHANNEL   3
+
+#define HAL_USE_USB TRUE
+#define HAL_USE_PAL TRUE
+
+#include_next <halconf.h>

--- a/firmware/geonix41/keyboard.json
+++ b/firmware/geonix41/keyboard.json
@@ -1,0 +1,486 @@
+{
+    "keyboard_name": "Geonix41",
+    "manufacturer": "RDMCTMZT",
+    "maintainer": "cognitom",
+    "usb": {
+        "vid": "0x36B0",
+        "pid": "0x313F",
+        "device_version": "0.0.5"
+    },
+    "matrix_pins": {
+        "cols": [
+            "D15",
+            "D14",
+            "C15",
+            "C14",
+            "C13",
+            "D3",
+            "D2",
+            "C12",
+            "C11",
+            "C10",
+            "A14",
+            "C9"
+        ],
+        "rows": [
+            "B0",
+            "B4",
+            "B5",
+            "B6"
+        ]
+    },
+    "diode_direction": "ROW2COL",
+    "features": {
+        "bootmagic": true,
+        "extrakey": true,
+        "nkro": true,
+        "mousekey": true,
+        "rgb_matrix": true
+    },
+    "rgb_matrix": {
+        "driver": "custom",
+        "animations": {
+            "solid_color": true,
+            "alphas_mods": true,
+            "gradient_up_down": true,
+            "gradient_left_right": true,
+            "breathing": true,
+            "band_sat": true,
+            "band_val": true,
+            "band_pinwheel_sat": true,
+            "band_pinwheel_val": true,
+            "band_spiral_sat": true,
+            "band_spiral_val": true,
+            "cycle_all": true,
+            "cycle_left_right": true,
+            "cycle_up_down": true,
+            "cycle_out_in": true,
+            "cycle_out_in_dual": true,
+            "rainbow_moving_chevron": true,
+            "cycle_pinwheel": true,
+            "cycle_spiral": true,
+            "dual_beacon": true,
+            "rainbow_beacon": true,
+            "rainbow_pinwheels": true,
+            "flower_blooming": true,
+            "raindrops": true,
+            "jellybean_raindrops": true,
+            "hue_breathing": true,
+            "hue_pendulum": true,
+            "hue_wave": true,
+            "pixel_fractal": false,
+            "pixel_flow": true,
+            "pixel_rain": false,
+            "typing_heatmap": false,
+            "digital_rain": true,
+            "solid_reactive_simple": false,
+            "solid_reactive": true,
+            "solid_reactive_wide": true,
+            "solid_reactive_multiwide": true,
+            "solid_reactive_cross": true,
+            "solid_reactive_multicross": true,
+            "solid_reactive_nexus": true,
+            "solid_reactive_multinexus": true,
+            "splash": true,
+            "multisplash": true,
+            "solid_splash": true,
+            "solid_multisplash": true,
+            "starlight": true,
+            "starlight_dual_hue": true,
+            "starlight_dual_sat": true,
+            "riverflow": true
+        }
+    },
+    "bootloader": "custom",
+    "layouts": {
+        "LAYOUT_ortho_4x12": {
+            "layout": [
+                {
+                    "matrix": [
+                        0,
+                        0
+                    ],
+                    "x": 0,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        1
+                    ],
+                    "x": 1,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        2
+                    ],
+                    "x": 2,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        3
+                    ],
+                    "x": 3,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        4
+                    ],
+                    "x": 4,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        5
+                    ],
+                    "x": 5,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        6
+                    ],
+                    "x": 6,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        7
+                    ],
+                    "x": 7,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        8
+                    ],
+                    "x": 8,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        9
+                    ],
+                    "x": 9,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        10
+                    ],
+                    "x": 10,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        0,
+                        11
+                    ],
+                    "x": 11,
+                    "y": 0
+                },
+                {
+                    "matrix": [
+                        1,
+                        0
+                    ],
+                    "x": 0,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        1
+                    ],
+                    "x": 1,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        2
+                    ],
+                    "x": 2,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        3
+                    ],
+                    "x": 3,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        4
+                    ],
+                    "x": 4,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        5
+                    ],
+                    "x": 5,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        6
+                    ],
+                    "x": 6,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        7
+                    ],
+                    "x": 7,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        8
+                    ],
+                    "x": 8,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        9
+                    ],
+                    "x": 9,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        10
+                    ],
+                    "x": 10,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        1,
+                        11
+                    ],
+                    "x": 11,
+                    "y": 1.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        0
+                    ],
+                    "x": 0,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        1
+                    ],
+                    "x": 1.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        2
+                    ],
+                    "x": 2.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        3
+                    ],
+                    "x": 3.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        4
+                    ],
+                    "x": 4.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        5
+                    ],
+                    "x": 5.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        6
+                    ],
+                    "x": 6.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        7
+                    ],
+                    "x": 7.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        8
+                    ],
+                    "x": 8.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        9
+                    ],
+                    "x": 9.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        10
+                    ],
+                    "x": 10.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        2,
+                        11
+                    ],
+                    "x": 11.5,
+                    "y": 2.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        0
+                    ],
+                    "x": 0,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        2
+                    ],
+                    "x": 1.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        3
+                    ],
+                    "x": 2.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        4
+                    ],
+                    "x": 3.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        5
+                    ],
+                    "x": 4.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        6
+                    ],
+                    "x": 5.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        1
+                    ],
+                    "x": 6.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        7
+                    ],
+                    "x": 7.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        8
+                    ],
+                    "x": 8.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        9
+                    ],
+                    "x": 9.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        10
+                    ],
+                    "x": 10.75,
+                    "y": 3.25
+                },
+                {
+                    "matrix": [
+                        3,
+                        11
+                    ],
+                    "x": 11.75,
+                    "y": 3.25
+                }
+            ]
+        }
+    },
+    "url": "https://github.com/cognitom/windmill"
+}

--- a/firmware/geonix41/keymaps/default/keymap.c
+++ b/firmware/geonix41/keymaps/default/keymap.c
@@ -1,0 +1,132 @@
+/* Copyright 2021-2026 Tsutomu Kawamura
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "windmill.h"
+#include "../../../lib/rdr_lib/rdr_common.h"
+
+/* レイヤー0(かな)とレイヤー1(英数)がベースレイヤーで、MY_LCTL のタップ/
+ * ダブルタップで切り替わる。レイヤー1で透過のキーはレイヤー0へ落ちる。
+ *
+ * MD_USB / MD_BLE1-3 / MD_24G は rdr_lib の無線モード切替キー (geonix41 専用)。 */
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [LAYER_KANA] = LAYOUT_ortho_4x12(
+    KC_ESC,  KC_1,         KC_2,         KC_3,        KC_4,          KC_5,           KC_6,           KC_7,          KC_8,           KC_9,    KC_0,    KC_ENT,
+    KC_TAB,  KC_Q,         MY_W,         KC_E,        MY_R,          KC_T,           KC_Y,           MY_U,          KC_I,           MY_O,    MY_P,    MY_LBRC,
+    KC_BSPC, MY_A,         KC_S,         KC_D,        KC_F,          KC_G,           KC_H,           KC_J,          MY_K,           MY_L,    MY_SCLN, MY_QUOT,
+    MY_LCTL, LGUI_T(KC_Z), LALT_T(KC_X), LT(3,KC_C),  LT(2,KC_V),    LSFT_T(KC_B),   RSFT_T(KC_N),   LT(2,KC_M),    LT(3,KC_COMMA), KC_DOT,  KC_SLSH, KC_GRV
+  ),
+
+  [LAYER_ALPHA] = LAYOUT_ortho_4x12(
+    _______, KC_Q,         KC_W,         KC_E,        KC_R,          KC_T,           KC_Y,           KC_U,          KC_I,           KC_O,    KC_P,    _______,
+    _______, KC_A,         KC_S,         KC_D,        KC_F,          KC_G,           KC_H,           KC_J,          KC_K,           KC_L,    KC_SCLN, KC_QUOT,
+    _______, KC_Z,         KC_X,         KC_C,        KC_V,          KC_B,           KC_N,           KC_M,          KC_COMM,        KC_DOT,  KC_UP,   KC_RGHT,
+    _______, KC_LGUI,      KC_LALT,      MO(3),       LT(2,KC_BSLS), LSFT_T(KC_SPC), LSFT_T(KC_SPC), LT(2,KC_SLSH), MO(3),          KC_APP,  KC_LEFT, KC_DOWN
+  ),
+
+  [LAYER_SYM] = LAYOUT_ortho_4x12(
+    _______, KC_1,         KC_2,         KC_3,        KC_4,          KC_5,           KC_6,           KC_7,          KC_8,           KC_9,       KC_0,    _______,
+    _______, S(KC_1),      S(KC_2),      S(KC_3),     S(KC_4),       S(KC_5),        S(KC_6),        S(KC_7),       S(KC_8),        S(KC_9),    S(KC_0), KC_GRV,
+    _______, KC_EQL,       S(KC_EQL),    KC_MINS,     S(KC_MINS),    KC_LBRC,        KC_RBRC,        S(KC_GRV),     S(KC_LBRC),     S(KC_RBRC), KC_UP,   KC_RGHT,
+    _______, _______,      _______,      _______,     _______,       S(KC_BSLS),     S(KC_SLSH),     _______,       _______,        _______,    KC_LEFT, KC_DOWN
+  ),
+
+  [LAYER_FN] = LAYOUT_ortho_4x12(
+    MD_USB,  MD_BLE1,      MD_BLE2,      MD_BLE3,     MD_24G,        KC_NO,          KC_NO,          MY_WIN,        MY_ANDR,        KC_NO,   QK_BOOT, MY_DARK,
+    KC_F1,   KC_F2,        KC_F3,        KC_F4,       KC_F5,         KC_F6,          KC_F7,          KC_F8,         KC_F9,          KC_F10,  KC_F11,  KC_F12,
+    KC_DEL,  KC_PSCR,      KC_NO,        KC_NO,       KC_NO,         KC_BRID,        KC_BRIU,        KC_MUTE,       KC_VOLD,        KC_VOLU, KC_UP,   KC_RGHT,
+    _______, _______,      _______,      _______,     _______,       _______,        _______,        _______,       _______,        _______, KC_LEFT, KC_DOWN
+  ),
+
+};
+
+/*
+ * Color settings
+ */
+
+enum keycolors {
+  CL_CONFIG,
+  CL_BASE,
+  CL_SPECIAL,
+  CL_SYMBOL,
+  CL_NUMBER,
+  CL_BRACKET,
+  CL_FUNC,
+  CL_MEDIA,
+};
+
+const uint8_t colorset[][6] = {
+  //             Light              Dark
+  //             (R,    G,    B   ) (R,    G,    B   )
+  [CL_CONFIG]  = {0x00, 0x33, 0x55,  0x00, 0x03, 0x05},
+  [CL_BASE]    = {0x07, 0x07, 0x05,  0x00, 0x00, 0x00},
+  [CL_SPECIAL] = {0x1c, 0x11, 0x00,  0x04, 0x03, 0x00},
+  [CL_SYMBOL]  = {0x11, 0x22, 0x22,  0x02, 0x04, 0x03},
+  [CL_NUMBER]  = {0x66, 0x66, 0x44,  0x06, 0x06, 0x04},
+  [CL_BRACKET] = {0x22, 0x33, 0x00,  0x02, 0x03, 0x00},
+  [CL_FUNC]    = {0x66, 0x66, 0x22,  0x06, 0x06, 0x02},
+  [CL_MEDIA]   = {0x00, 0x33, 0x55,  0x00, 0x03, 0x05},
+};
+
+/* dual-role キーはタップ側のキーコードに展開されてから渡される。
+ * S(KC_x) はそのまま (シフト付きの記号として分類したいため)。 */
+uint8_t windmill_process_keycolor_user(uint8_t layer, uint16_t keycode) {
+  /* かなレイヤーはOSのIMEがかなに変換するので、キーコードからは色を決められない
+   * (KC_1 は「ぬ」、KC_SLSH は「め」…)。かなが打てるキーは全て CL_BASE にする。 */
+  if (layer == LAYER_KANA) {
+    switch (keycode) {
+      case KC_ENT ... KC_TAB: // Enter, Esc, BSpc, Tab
+      case MY_LCTL:           // 英数/かな
+        return CL_SPECIAL;
+    }
+    return CL_BASE;
+  }
+
+  switch (keycode) {
+    case MY_WIN: case MY_ANDR: case MY_DARK: case QK_BOOT:
+    case MD_USB: case MD_BLE1: case MD_BLE2: case MD_BLE3: case MD_24G:
+      return CL_CONFIG;
+    case KC_ENT ... KC_TAB: case KC_DEL: case KC_RIGHT ... KC_UP:
+    case KC_APP: case KC_INT1 ... KC_LNG2: case KC_LCTL ... KC_RGUI:
+    case MY_LCTL: case QK_MOMENTARY ... QK_MOMENTARY_MAX:
+      return CL_SPECIAL;
+    case KC_MINS ... KC_EQL: case KC_BSLS ... KC_SLSH:
+    case S(KC_1) ... S(KC_8): case S(KC_MINS) ... S(KC_EQL):
+    case S(KC_BSLS) ... S(KC_GRV): case S(KC_SLSH):
+    case MY_SCLN: case MY_QUOT:
+      return CL_SYMBOL;
+    case KC_1 ... KC_0:
+      return CL_NUMBER;
+    case S(KC_COMM) ... S(KC_DOT): case S(KC_9) ... S(KC_0):
+    case KC_LBRC ... KC_RBRC: case S(KC_LBRC) ... S(KC_RBRC):
+    case MY_LBRC:
+      return CL_BRACKET;
+    case KC_F1 ... KC_PGUP: case KC_END ... KC_PGDN:
+      return CL_FUNC;
+    case KC_MUTE ... KC_VOLD: case KC_BRIU ... KC_BRID:
+      return CL_MEDIA;
+  }
+  return CL_BASE;
+}
+
+/*
+ * QMK callbacks
+ */
+
+void keyboard_post_init_user(void) {
+  windmill_init_keycolors((uint8_t*)colorset);
+}

--- a/firmware/geonix41/mcuconf.h
+++ b/firmware/geonix41/mcuconf.h
@@ -1,0 +1,23 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+    ChibiOS - Copyright (C) 2021 Stefan Kerkmann
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#define ES32_USB_USE_USB0 TURE
+
+//#include_next <mcuconf.h>
+

--- a/firmware/geonix41/readme.md
+++ b/firmware/geonix41/readme.md
@@ -1,0 +1,67 @@
+# Geonix41
+
+Windmill の4機種目。ES32 FS026 (Cortex-M0) を積んだ、USB / BLE×3 / 2.4G の三モード機。
+
+* Keyboard Maintainer: [cognitom](https://github.com/cognitom)
+* Hardware Supported: Geonix REV.2.5 1U (RDMCTMZT)
+
+```sh
+bash scripts/build.sh   # 4機種まとめてビルドされる
+```
+
+書き込みは MSC (USBドライブ) 型ブートローダー。Esc を押しながら USB 接続すると
+FAT ドライブが現れるので、`output/windmill_geonix41.bin` をコピーするだけ。
+`make :flash` や QMK Toolbox は使えない (`bootloader: custom`)。
+
+## 他の3機種と違うところ
+
+Windmill の他の機種は素の QMK でビルドできるが、この機種だけは違う。
+
+### ベンダーブロブが要る
+
+無線 (BLE/2.4G)・電源管理・LEDドライバ・キースキャン後段の `Key_Value_Dispose()` は
+`librdrcommon.a` というクローズドソースのライブラリが持っている。再配布しないので
+リポジトリには置かず、`scripts/fetch-vendor-blob.py` がベンダー配布の zip から
+取り出して `vendor/` に置く (`build.sh` が自動で呼ぶ)。
+
+配布 zip は約1GB あるが、必要なのは 2 ファイル・計 97KB だけなので、
+HTTP の Range リクエストで該当部分だけ抜いている (転送量 4.5MB / 10秒程度)。
+
+### QMK コアにパッチが要る
+
+ブロブは HID レポートの送出経路を QMK 標準から丸ごと差し替える。
+そのため `patches/qmk-core-rdr-lib.patch` を当てないとビルドできない。
+また ES32 のクロックと USB まわりに `patches/es32-fs026-geonix41.patch` が要る。
+
+ブロブは単一オブジェクトなので、リンクすると `del_key_from_report()` のような
+コア関数の実装まで一緒に入ってくる。パッチ側では同名の定義を落としてあり、
+**この状態で他の機種をビルドすると未定義参照で落ちる**。
+`scripts/entrypoint.sh` が他の3機種を先にビルドし、最後に geonix41 をやるのはこのため。
+
+### rules.mk と config.h を持つ
+
+ES32 は QMK が知らない MCU なので、`keyboard.json` だけではボード設定を書けない。
+Windmill でこの2ファイルを持つのはこの機種だけ。
+
+### qmk lint を `--strict` で走らせていない
+
+`Option "debounce" duplicates default value of "5"` が出るが、これは誤検知。
+`quantum/debounce/asym_eager_defer_pk.c` は `DEBOUNCE` 未定義でも 5 に
+フォールバックする一方、`quantum/bootmagic/bootmagic.c` は `BOOTMAGIC_DEBOUNCE` を
+`DEBOUNCE * 2` で作り、`DEBOUNCE` が見えないときだけ 30 に落ちる。
+消すと起動時 (Esc押し) の待ちが 10ms → 30ms に変わるので、`config.h` から
+消してはいけない。
+
+## キーコードの番号
+
+`rdr_lib` が `QK_KB_0` から30個、自前のキーコード (無線モード切替など) を並べている。
+Windmill の `MY_*` はぶつからないよう `QK_KB_30` から始める
+(`config.h` の `WINDMILL_KEYCODE_BASE`)。ズレたら `geonix41.c` の
+`_Static_assert` が検知する。
+
+## LED
+
+キー下 48個 (LED 0〜47) とアンダーグロー 29個 (48〜76)。
+Windmill が配色を塗るのはキー下だけで、アンダーグローと電池残量・ペアリング表示は
+ベンダー実装 (`User_Led_Show()`) に任せている。順序はベンダー → Windmill なので、
+配色が上に乗る。

--- a/firmware/geonix41/rules.mk
+++ b/firmware/geonix41/rules.mk
@@ -1,0 +1,39 @@
+# Geonix41 (ES32 FS026 / Cortex-M0)
+#
+# windmill で唯一 rules.mk / config.h を持つ機種。ES32 は QMK が知らない MCU なので、
+# keyboard.json だけでは ChibiOS のボード設定を書けない。
+
+# Board: <chibios-contrib>/os/hal/boards/FS026
+BOARD = FS026
+
+MCU  = cortex-m0
+ARMV = 6
+
+MCU_FAMILY = ES32
+MCU_SERIES = FS026
+
+MCU_LDSCRIPT ?= FS026
+MCU_STARTUP  ?= FS026
+
+USE_FPU ?= no
+
+# EEPROMは rdr_lib (librdrcommon.a) の実装を使う
+EEPROM_DRIVER = custom
+NO_USB_STARTUP_CHECK = yes
+BLUETOOTH_CUSTOM = yes
+
+DEBOUNCE_TYPE = asym_eager_defer_pk
+
+# ES32 の CMSIS ヘッダ (chibios-contrib 同梱の system_fs026.h) はインクルードガードの
+# マクロ名が綴り違いで、GCC 15 の -Wheader-guard に引っかかる。ベンダー由来のコードなので
+# 直さず警告だけ落とす。QMK は -Werror なので、これがないとビルドが止まる。
+CFLAGS += -Wno-error=header-guard
+
+# ベンダーブロブ。無線 (BLE/2.4G)・電源管理・LEDドライバと、キースキャン後段の
+# Key_Value_Dispose() を提供する。scripts/fetch-vendor-blob.py がリポジトリの vendor/ に
+# 置き、build.sh が QMK ツリーの lib/rdr_lib/ へマウントする。
+#
+# 単一オブジェクト (rdr_common.o) なので、リンクすると del_key_from_report() など
+# コア関数の実装も一緒に入ってくる。patches/qmk-core-rdr-lib.patch を当てた
+# report.c 側では同名の定義を落としてあり、この行とパッチは対で扱うこと。
+LDFLAGS += -L$(LIB_PATH)/rdr_lib -lrdrcommon

--- a/firmware/windmill.c
+++ b/firmware/windmill.c
@@ -28,6 +28,14 @@
 
 #define KEY_COUNT (MATRIX_ROWS * MATRIX_COLS)
 
+/* 機種固有の割り込み口 (windmill.h 参照)。既定は何もしない */
+__attribute__((weak)) void windmill_board_post_init(void) {}
+__attribute__((weak)) void windmill_board_pre_process_record(uint16_t keycode, keyrecord_t *record) {}
+__attribute__((weak)) bool windmill_board_process_record(uint16_t keycode, keyrecord_t *record) {
+    return true;
+}
+__attribute__((weak)) void windmill_board_led_begin(void) {}
+
 typedef union {
     uint32_t raw;
     struct {
@@ -336,6 +344,8 @@ static bool is_sym_ime_wrap_target(uint16_t keycode) {
 // キーコード確定「前」に呼ばれるため、ここで layer_on すれば
 // 割り込みキーがレイヤー1 + Ctrl で解決される
 bool pre_process_record_kb(uint16_t keycode, keyrecord_t *record) {
+    windmill_board_pre_process_record(keycode, record);
+
     if (keycode != MY_LCTL && record->event.pressed) {
         if (td_phase == TD_PRESSED && !td_hold_active) {
             td_hold_on(); // 割り込み → 即ホールド確定
@@ -433,7 +443,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
             return false;
     }
 
-    return true;
+    return windmill_board_process_record(keycode, record);
 }
 
 void matrix_scan_kb(void) {
@@ -476,6 +486,8 @@ void keyboard_post_init_kb(void) {
     led_initialized = true;
     refresh_keycolors(layer_state, default_layer_state);
 #endif // WINDMILL_LED_ENABLE
+
+    windmill_board_post_init();
 }
 
 #ifdef WINDMILL_LED_ENABLE
@@ -496,6 +508,10 @@ layer_state_t default_layer_state_set_kb(layer_state_t state) {
 #    ifdef RGB_MATRIX_ENABLE
 bool rgb_matrix_indicators_kb(void) {
     if (!rgb_matrix_indicators_user()) return false;
+
+    // ベンダー実装の描画を先に走らせる。配色はこの上から塗る
+    windmill_board_led_begin();
+
     if (!led_on || !led_initialized) return true;
 
     apply_keycolors();

--- a/firmware/windmill.h
+++ b/firmware/windmill.h
@@ -34,11 +34,18 @@
 #define THUMB_SHIFT_B LSFT_T(KC_B)
 #define THUMB_SHIFT_N RSFT_T(KC_N)
 
+/* カスタムキーコードの開始位置。通常は QK_KB_0 から。ただし geonix41 のように
+ * ベンダーのライブラリが QK_KB_0 から自前のキーコードを並べている機種では、
+ * ぶつからないよう後ろにずらす必要があるので、機種の config.h で上書きする。 */
+#ifndef WINDMILL_KEYCODE_BASE
+#    define WINDMILL_KEYCODE_BASE QK_KB_0
+#endif
+
 /* geonix41/minipeg48 から移植したカスタムキーコード。
  * MY_W 〜 MY_A は my_shift_pairs[] のインデックス (keycode - MY_W) に
  * 使っているので、並び順を変えないこと。 */
 enum windmill_keycodes {
-    MY_O = QK_KB_0, // Shift時: 「
+    MY_O = WINDMILL_KEYCODE_BASE, // Shift時: 「
     MY_P,           // Shift時: 」
     MY_LCTL,        // tap: 英数, double-tap: かな, hold: Ctrl + 英数レイヤー
     MY_W,           // Shift時: +
@@ -71,3 +78,21 @@ uint8_t windmill_process_keycolor_user(uint8_t layer, uint16_t keycode);
 uint16_t windmill_base_keycode(uint16_t keycode);
 
 #endif // WINDMILL_LED_ENABLE
+
+/* 機種固有の割り込み口。windmill.c が QMK の *_kb フックを占有しているので、
+ * ベンダーのライブラリを呼ぶ必要がある機種 (geonix41) 向けに weak で開けてある。
+ * 実装しない機種では何もしない。 */
+
+// keyboard_post_init_kb() の最後
+void windmill_board_post_init(void);
+
+/* すべてのキーイベントの入口 (pre_process_record_kb)。MY_* のように windmill が
+ * 途中で消費するキーでも必ず通るので、スリープ抑止などはこちらで行う。 */
+void windmill_board_pre_process_record(uint16_t keycode, keyrecord_t *record);
+
+/* process_record_kb() の最後。windmill が消費しなかったキーだけが渡る。
+ * false を返すとキーはそこで消費される。 */
+bool windmill_board_process_record(uint16_t keycode, keyrecord_t *record);
+
+// LEDを流し込む直前。ベンダー側の描画を先に走らせてから配色を上書きするために使う
+void windmill_board_led_begin(void);

--- a/patches/es32-fs026-geonix41.patch
+++ b/patches/es32-fs026-geonix41.patch
@@ -1,0 +1,116 @@
+diff --git a/os/hal/ports/ES32/FS026/hal_lld.c b/os/hal/ports/ES32/FS026/hal_lld.c
+index ca62a745..81a438f9 100644
+--- a/os/hal/ports/ES32/FS026/hal_lld.c
++++ b/os/hal/ports/ES32/FS026/hal_lld.c
+@@ -74,24 +74,12 @@ const md_rcu_init_typedef rcu_initStruct =    /**< RCU init structure */
+ {
+     MD_RCU_MPRE_MCO_DIV1,
+     MD_RCU_MSW_MCO_DISABLE,
+-    ES32_PLL_SOURSE_SELECT,
+-    ES32_PLL_CLK_FREQ,
+-    ES32_BUS_DIV_PPRE,
+-    ES32_BUS_DIV_HPRE,
+-    ES32_SYSCLK_SOURSE_SELECT,
+-#if ES32_PLL_CLK_EN
+-#if ES32_HOSC_CLK_EN
+-    (RCU_CON_HRCON | RCU_CON_HRC48ON_MSK | RCU_CON_PLL0ON | RCU_CON_HOSCON),
+-#else
+-    (RCU_CON_HRCON | RCU_CON_HRC48ON_MSK | RCU_CON_PLL0ON),
+-#endif
+-#else
+-#if ES32_HOSC_CLK_EN
+-    (RCU_CON_HRCON | RCU_CON_HRC48ON_MSK | RCU_CON_HOSCON),
+-#else
++    MD_RCU_PLLSRC_HRC48,
++    MD_RCU_PLLCLK_PASS,
++    MD_RCU_PPRE_HCLK_DIV_1,
++    MD_RCU_HPRE_SYSCLK_DIV_1,
++    MD_RCU_SW_SYSCLK_HRC48,
+     (RCU_CON_HRCON | RCU_CON_HRC48ON_MSK),
+-#endif
+-#endif
+ };
+ 
+ /**
+@@ -102,21 +90,21 @@ const md_rcu_init_typedef rcu_initStruct =    /**< RCU init structure */
+ void hal_lld_init(void)
+ {
+     __disable_irq();
+-#if ES32_PLL_CLK_EN
+-    md_rcu_pll0_init(RCU, (md_rcu_init_typedef*)(&rcu_initStruct));
+-#endif
++//#if ES32_PLL_CLK_EN
++    //md_rcu_pll0_init(RCU, (md_rcu_init_typedef*)(&rcu_initStruct));
++//#endif
+     md_rcu_sys_init(RCU, (md_rcu_init_typedef*)(&rcu_initStruct));
+     md_rcu_enable_gpioa(RCU);
+     md_rcu_enable_gpiob(RCU);
+     md_rcu_enable_gpioc(RCU);
+     md_rcu_enable_gpiod(RCU);
+     md_rcu_enable_usb(RCU);
+-#if ES32_USE_USB_SOF_TRIM_HRC48
++//#if ES32_USE_USB_SOF_TRIM_HRC48
+     /*Using USB_SOF to calibrate the internal clock*/
+     md_rcu_enable_csu(RCU);
+     CSU->CON |= CSU_CON_AUTOEN_MSK;
+     CSU->CON |= CSU_CON_CNTEN_MSK;
+-#endif
++//#endif
+     __enable_irq();
+ }
+ #endif
+diff --git a/os/hal/ports/ES32/LLD/TIMv1/hal_st_lld.c b/os/hal/ports/ES32/LLD/TIMv1/hal_st_lld.c
+index 7e31a2a8..fecec167 100644
+--- a/os/hal/ports/ES32/LLD/TIMv1/hal_st_lld.c
++++ b/os/hal/ports/ES32/LLD/TIMv1/hal_st_lld.c
+@@ -81,7 +81,7 @@ OSAL_IRQ_HANDLER(SysTick_Handler)
+ void st_lld_init(void)
+ {
+ #if (OSAL_ST_MODE == OSAL_ST_MODE_PERIODIC)
+-    SysTick->LOAD = 72000 - 1;
++    SysTick->LOAD = 48000 - 1;
+     SysTick->CTRL = 0x10007;
+     
+ #endif /* OSAL_ST_MODE == OSAL_ST_MODE_PERIODIC */
+diff --git a/os/hal/ports/ES32/LLD/USBv1/hal_usb_lld.c b/os/hal/ports/ES32/LLD/USBv1/hal_usb_lld.c
+index 50369d76..8e6fd53f 100644
+--- a/os/hal/ports/ES32/LLD/USBv1/hal_usb_lld.c
++++ b/os/hal/ports/ES32/LLD/USBv1/hal_usb_lld.c
+@@ -442,7 +442,7 @@ int usbd_ep_start_write(const uint8_t ep, const uint8_t *data, uint32_t data_len
+     old_ep_idx = musb_get_active_ep();
+     musb_set_active_ep(ep_idx);
+     
+-    if((USB->CSR0L_TXCSRL) & USB_TXCSRL_TXRDY_MSK)
++    if(es_usbd_ep_tx_ready_state(ep_idx))
+     {
+         musb_set_active_ep(old_ep_idx);
+         return -3;
+@@ -549,6 +549,11 @@ void handle_ep0(void)
+         USB->CSR0L_TXCSRL = ALD_USB_CSR0L_SETENDC;
+     }
+ 
++    if (g_musb_udc.dev_addr > 0) {
++        USB->FADDR = g_musb_udc.dev_addr;
++        g_musb_udc.dev_addr = 0;
++    }
++
+     switch (usb_ep0_state) {
+         case USB_EP0_STATE_SETUP:
+             if (ep0_status & ALD_USB_CSR0L_RXRDY) {
+@@ -937,11 +942,11 @@ void usb_lld_reset(USBDriver *usbp)
+  */
+ void usb_lld_set_address(USBDriver *usbp)
+ {
+-    volatile uint32_t i;
+-    
+-    for(i = 0;i < 9999;i++){}
+-    
+-    USB->FADDR = usbp->address;
++    if (usbp->address == 0) {
++        ald_usb_dev_set_addr(0);
++    }
++
++    g_musb_udc.dev_addr = usbp->address;
+ }
+ 
+ /**

--- a/patches/qmk-core-rdr-lib.patch
+++ b/patches/qmk-core-rdr-lib.patch
@@ -1,0 +1,196 @@
+diff --git a/quantum/action_util.c b/quantum/action_util.c
+index 00cec24e3f..4636e299aa 100644
+--- a/quantum/action_util.c
++++ b/quantum/action_util.c
+@@ -26,8 +26,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ extern keymap_config_t keymap_config;
+ 
+-static uint8_t real_mods = 0;
+-static uint8_t weak_mods = 0;
++/* rdr_lib のブロブがレポート組み立てのために直接参照するので非 static */
++uint8_t real_mods = 0;
++uint8_t weak_mods = 0;
+ #ifdef KEY_OVERRIDE_ENABLE
+ static uint8_t weak_override_mods = 0;
+ static uint8_t suppressed_mods    = 0;
+@@ -333,13 +334,15 @@ void send_nkro_report(void) {
+  * FIXME: needs doc
+  */
+ void send_keyboard_report(void) {
+-#ifdef NKRO_ENABLE
+-    if (host_can_send_nkro() && keymap_config.nkro) {
+-        send_nkro_report();
+-        return;
++    /* USB・BLE・2.4G のどれで送るかはブロブ側が握っているので、レポート送出は
++     * QMK の send_{6kro,nkro}_report() ではなくブロブの実装に委ねる。
++     * NKRO レポートを使うのは add_key_to_report() が 6KRO の6枠を使い切って
++     * ビットマップ側に溢れたとき (User_Send_Type) だけ */
++    if (keymap_config.User_Send_Type && keymap_config.nkro) {
++        User_send_nkro_report();
++    } else {
++        User_send_6kro_report();
+     }
+-#endif
+-    send_6kro_report();
+ }
+ 
+ /**
+@@ -362,6 +365,7 @@ mod_t get_mod_state(void) {
+  */
+ void add_mods(uint8_t mods) {
+     real_mods |= mods;
++    keymap_config.User_Send_Type = false;
+ }
+ /** \brief del mods
+  *
+@@ -369,6 +373,7 @@ void add_mods(uint8_t mods) {
+  */
+ void del_mods(uint8_t mods) {
+     real_mods &= ~mods;
++    keymap_config.User_Send_Type = false;
+ }
+ /** \brief set mods
+  *
+diff --git a/quantum/action_util.h b/quantum/action_util.h
+index f3178bba6e..4125e030ad 100644
+--- a/quantum/action_util.h
++++ b/quantum/action_util.h
+@@ -23,6 +23,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include "report.h"
+ #include "modifiers.h"
+ 
++/* rdr_lib のブロブが直接読み書きするので公開している */
++extern uint8_t real_mods;
++extern uint8_t weak_mods;
++
++/* rdr_lib (librdrcommon.a) が提供するレポート送出。接続先が USB か BLE か 2.4G かは
++ * ブロブ側が判断する。QMK の send_{6kro,nkro}_report() の代わりに使う */
++void User_send_6kro_report(void);
++void User_send_nkro_report(void);
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff --git a/quantum/keycode_config.h b/quantum/keycode_config.h
+index 804f1381d0..76477f4d25 100644
+--- a/quantum/keycode_config.h
++++ b/quantum/keycode_config.h
+@@ -42,6 +42,9 @@ typedef union keymap_config_t {
+         bool oneshot_enable : 1;
+         bool swap_escape_capslock : 1;
+         bool autocorrect_enable : 1;
++        /* rdr_lib 向け。add_key_to_report() が 6KRO の6枠から溢れて NKRO の
++         * ビットマップ側にキーを積んだことを send_keyboard_report() に伝える */
++        bool User_Send_Type : 1;
+     };
+ } keymap_config_t;
+ 
+diff --git a/tmk_core/protocol/report.c b/tmk_core/protocol/report.c
+index 8cae256cc6..b0bdd40e1a 100644
+--- a/tmk_core/protocol/report.c
++++ b/tmk_core/protocol/report.c
+@@ -19,10 +19,14 @@
+ #include "host.h"
+ #include "keycode_config.h"
+ #include "debug.h"
+-#include "usb_device_state.h"
+ #include "util.h"
+ #include <string.h>
+ 
++/* このファイルの NKRO 判定からは host_can_send_nkro() を外してある。
++ * これは USB のプロトコル状態 (usb_device_state) を見るため、rdr_lib で
++ * BLE / 2.4G 接続しているときは常に false になり NKRO が死ぬ。
++ * 接続先の判断はブロブ側が持っているので、ここでは keymap_config.nkro だけを見る */
++
+ /** \brief has_anykey
+  *
+  * FIXME: Needs doc
+@@ -32,7 +36,7 @@ uint8_t has_anykey(void) {
+     uint8_t* p   = keyboard_report->keys;
+     uint8_t  lp  = sizeof(keyboard_report->keys);
+ #ifdef NKRO_ENABLE
+-    if (host_can_send_nkro() && keymap_config.nkro) {
++    if (keymap_config.nkro) {
+         p  = nkro_report->bits;
+         lp = sizeof(nkro_report->bits);
+     }
+@@ -49,7 +53,7 @@ uint8_t has_anykey(void) {
+  */
+ uint8_t get_first_key(void) {
+ #ifdef NKRO_ENABLE
+-    if (host_can_send_nkro() && keymap_config.nkro) {
++    if (keymap_config.nkro) {
+         uint8_t i = 0;
+         for (; i < NKRO_REPORT_BITS && !nkro_report->bits[i]; i++)
+             ;
+@@ -69,7 +73,7 @@ bool is_key_pressed(uint8_t key) {
+         return false;
+     }
+ #ifdef NKRO_ENABLE
+-    if (host_can_send_nkro() && keymap_config.nkro) {
++    if (keymap_config.nkro) {
+         if ((key >> 3) < NKRO_REPORT_BITS) {
+             return nkro_report->bits[key >> 3] & 1 << (key & 7);
+         } else {
+@@ -147,32 +151,34 @@ void del_key_bit(report_nkro_t* nkro_report, uint8_t code) {
+ 
+ /** \brief add key to report
+  *
+- * FIXME: Needs doc
++ * rdr_lib 版: まず 6KRO レポートの6枠を埋め、溢れたぶんだけ NKRO のビットマップに積む。
++ * どちらを送るかは User_Send_Type で send_keyboard_report() に伝える。
++ * 常時 NKRO レポートを投げないのは、BIOS など boot protocol しか解さない相手でも
++ * 6キーまでは素通りさせるため。
+  */
+ void add_key_to_report(uint8_t key) {
+-#ifdef NKRO_ENABLE
+-    if (host_can_send_nkro() && keymap_config.nkro) {
+-        add_key_bit(nkro_report, key);
+-        return;
++    for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; i++) {
++        if (keyboard_report->keys[i] == 0x00) {
++            keyboard_report->keys[i]     = key;
++            keymap_config.User_Send_Type = false;
++            return;
++        }
+     }
+-#endif
+-    add_key_byte(keyboard_report, key);
+-}
+ 
+-/** \brief del key from report
+- *
+- * FIXME: Needs doc
+- */
+-void del_key_from_report(uint8_t key) {
+ #ifdef NKRO_ENABLE
+-    if (host_can_send_nkro() && keymap_config.nkro) {
+-        del_key_bit(nkro_report, key);
+-        return;
++    if (keymap_config.nkro) {
++        if ((key >> 3) < NKRO_REPORT_BITS) {
++            nkro_report->bits[key >> 3] |= 1 << (key & 7);
++            keymap_config.User_Send_Type = true;
++        }
+     }
+ #endif
+-    del_key_byte(keyboard_report, key);
+ }
+ 
++/* del_key_from_report() は rdr_lib (librdrcommon.a) 側が定義している。
++ * ブロブは単一オブジェクトなのでリンクすると必ず持ち込まれ、ここに定義を残すと
++ * 多重定義になる。add_key_to_report() の 6KRO/NKRO 二段構えと対になる実装 */
++
+ /** \brief clear key from report
+  *
+  * FIXME: Needs doc
+@@ -180,7 +186,7 @@ void del_key_from_report(uint8_t key) {
+ void clear_keys_from_report(void) {
+     // not clear mods
+ #ifdef NKRO_ENABLE
+-    if (host_can_send_nkro() && keymap_config.nkro) {
++    if (keymap_config.nkro) {
+         memset(nkro_report->bits, 0, sizeof(nkro_report->bits));
+         return;
+     }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,10 +14,16 @@ if [ -z "$(docker image ls -q "$image")" ]; then
   docker build -t "$image" -f ./scripts/Dockerfile .
 fi
 
+# geonix41 のベンダーブロブ。リポジトリには置けないので毎回ここで揃える
+# (取得済みなら何もしない)
+python3 ./scripts/fetch-vendor-blob.py
+
 # Run container and build firmware
 docker run \
   --interactive --rm \
   --mount type=bind,source="$dirpath/firmware",target="/qmk_firmware/keyboards/$project" \
+  --mount type=bind,source="$dirpath/patches",target="/patches",readonly \
+  --mount type=bind,source="$dirpath/vendor",target="/qmk_firmware/lib/rdr_lib",readonly \
   --mount type=bind,source="$dirpath/output",target="/output" \
   --mount type=bind,source="$dirpath/scripts/entrypoint.sh",target="/entrypoint.sh" \
   --entrypoint /bin/bash \

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,10 +9,40 @@ fi
 host_uid=$(ls -n "$0" | awk '{print $3}') # study who my owner is
 host_gid=$(ls -n "$0" | awk '{print $4}') # study what I belong to
 
+# 素のQMKで通る機種。geonix41 より先にビルドすること (下のコメント参照)
 for keyboard in technik ymd40 minipeg48; do
   qmk lint -kb "windmill/$keyboard" -km default --strict
   make "windmill/$keyboard:default"
   mv "windmill_${keyboard}_default.hex" "/output/windmill_${keyboard}.hex"
 done
 
-chown "$host_uid:$host_gid" /output/*.hex
+# ここから先は素のQMKではなくなる。
+#
+# geonix41 のベンダーブロブ (librdrcommon.a) は HIDレポートの送出経路を QMK標準から
+# 丸ごと差し替えるため、コアにパッチが要る。しかもブロブは単一オブジェクトなので、
+# リンクすると del_key_from_report() などコア関数の実装まで持ち込まれる。
+# パッチ側ではその同名定義を落としてあり、**この状態で geonix41 以外をビルドすると
+# 未定義参照で落ちる**。だから最後に回している。
+#
+# コンテナは --rm の使い捨てなので、パッチを剥がす処理は要らない。
+echo '--- applying vendor patches (QMK core is no longer pristine from here) ---'
+git apply /patches/qmk-core-rdr-lib.patch
+git -C lib/chibios-contrib apply /patches/es32-fs026-geonix41.patch
+
+# geonix41 の lint は debounce の指摘1件だけ既知の誤検知として見逃す。
+# (消すと起動時の待ちが変わる。firmware/geonix41/readme.md 参照)
+# それ以外の指摘が出たらちゃんと落とす。
+lint_out=$(qmk lint -kb "windmill/geonix41" -km default --strict 2>&1 || true)
+echo "$lint_out"
+# ☒ の行から、既知の1件と最後のまとめ行を除いて、まだ残るものがあれば落とす
+if echo "$lint_out" | grep '☒' \
+     | grep -v 'duplicates default value of "5"' \
+     | grep -qv 'Lint check failed for'; then
+  echo '🚨 geonix41 の lint に既知以外の指摘がある' 1>&2
+  exit 1
+fi
+
+make "windmill/geonix41:default"
+mv "windmill_geonix41_default.bin" "/output/windmill_geonix41.bin"
+
+chown "$host_uid:$host_gid" /output/*.hex /output/*.bin

--- a/scripts/fetch-vendor-blob.py
+++ b/scripts/fetch-vendor-blob.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""geonix41 のベンダーブロブを Google Drive の配布 zip から取り出す。
+
+配布物は QMK ソース一式の zip で **約1GB** あるが、必要なのは 2 ファイル (計 97KB) だけ。
+zip は末尾の中央ディレクトリから各メンバの位置を引ける形式なので、HTTP の Range
+リクエストで「中央ディレクトリ → 目的のメンバ」とピンポイントに取れば
+**転送量 4.5MB・10秒程度**で済む。1GB を落とす必要はない。
+
+出力先の 2 ファイルが既に正しい sha256 で存在していれば何もしない (冪等)。
+"""
+
+import hashlib
+import pathlib
+import struct
+import sys
+import urllib.request
+import zlib
+
+# ベンダー配布物 (公開リンク)。差し替えたら EXPECTED も更新すること
+DRIVE_FILE_ID = "1Xv3MLWRJ2NYUFQUfYOxqfMQ_e2bGl3Jv"
+ZIP_NAME = "qmk_firmware_Rev.2.5-1U.zip"
+URL = (
+    "https://drive.usercontent.google.com/download"
+    f"?id={DRIVE_FILE_ID}&export=download&confirm=t"
+)
+
+# QMK ツリーの lib/rdr_lib/ に相当する。keyboards/ の下に置くと qmk lint が
+# 「あるはずのないファイル」として弾くので、外に出してある
+OUT_DIR = pathlib.Path(__file__).resolve().parent.parent / "vendor"
+
+# zip 内のパス末尾 → (出力名, 改行をLFに正規化するか, 出力後の sha256)
+#
+# rdr_common.h は zip 内では CRLF。QMK ツリーに合わせて LF に正規化して置く
+# (zip 内の生バイトの sha256 は f0a1c6ec97020d8fc2d7143277d38b6181d1306d347ea2e32b588b71f8bbbf39)。
+MEMBERS = {
+    "lib/rdr_lib/librdrcommon.a": (
+        "librdrcommon.a",
+        False,
+        "7a2dba53e3b564ed412bc1648ae570fb134bbe15ee505f72c7c94d7c227e560d",
+    ),
+    "lib/rdr_lib/rdr_common.h": (
+        "rdr_common.h",
+        True,
+        "61385d2308b855bc1580c880a6a7407e35daf7884824fc24eb5c99943b16a588",
+    ),
+}
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def fetch(start: int, end: int) -> bytes:
+    """[start, end] を Range で取る (end は含む)。"""
+    req = urllib.request.Request(URL, headers={"Range": f"bytes={start}-{end}"})
+    with urllib.request.urlopen(req) as res:
+        if res.status != 206:
+            sys.exit(
+                f"🚨 Range リクエストが効いていない (HTTP {res.status})。\n"
+                f"   配布物が非公開になったか、Drive の仕様が変わった可能性がある。\n"
+                f"   {ZIP_NAME} を手で落として lib/rdr_lib/ の中身を vendor/ に置いてほしい。"
+            )
+        return res.read()
+
+
+def total_size() -> int:
+    req = urllib.request.Request(URL, headers={"Range": "bytes=0-0"})
+    with urllib.request.urlopen(req) as res:
+        return int(res.headers["content-range"].split("/")[1])
+
+
+def already_ok() -> bool:
+    for out_name, _, want in MEMBERS.values():
+        path = OUT_DIR / out_name
+        if not path.is_file() or sha256(path.read_bytes()) != want:
+            return False
+    return True
+
+
+def locate_members() -> dict:
+    """中央ディレクトリを読んで、必要なメンバの位置情報を集める。"""
+    size = total_size()
+
+    # EOCD (End Of Central Directory) は末尾にある。コメント最大 65535 + ヘッダ 22
+    tail = fetch(max(0, size - 65558), size - 1)
+    pos = tail.rfind(b"PK\x05\x06")
+    if pos < 0:
+        sys.exit("🚨 zip の EOCD が見つからない。配布物が壊れているか zip ではない")
+    cd_size, cd_offset = struct.unpack("<II", tail[pos + 12 : pos + 20])
+
+    cd = fetch(cd_offset, cd_offset + cd_size - 1)
+
+    found, p = {}, 0
+    while p < len(cd) and cd[p : p + 4] == b"PK\x01\x02":
+        method, = struct.unpack("<H", cd[p + 10 : p + 12])
+        comp_size, = struct.unpack("<I", cd[p + 20 : p + 24])
+        name_len, extra_len, comment_len = struct.unpack("<HHH", cd[p + 28 : p + 34])
+        local_offset, = struct.unpack("<I", cd[p + 42 : p + 46])
+        name = cd[p + 46 : p + 46 + name_len].decode("utf-8", "replace")
+        for want in MEMBERS:
+            if name.endswith(want):
+                found[want] = (local_offset, comp_size, method, name)
+        p += 46 + name_len + extra_len + comment_len
+
+    missing = set(MEMBERS) - set(found)
+    if missing:
+        sys.exit(f"🚨 zip 内に見つからない: {', '.join(sorted(missing))}")
+    return found
+
+
+def extract(local_offset: int, comp_size: int, method: int) -> bytes:
+    # ローカルヘッダは 30 バイト + ファイル名 + extra。実データはその後ろ
+    header = fetch(local_offset, local_offset + 29)
+    name_len, extra_len = struct.unpack("<HH", header[26:30])
+    start = local_offset + 30 + name_len + extra_len
+    data = fetch(start, start + comp_size - 1)
+    if method == 0:
+        return data
+    if method == 8:
+        return zlib.decompress(data, -15)
+    sys.exit(f"🚨 未対応の圧縮方式: {method}")
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    if already_ok():
+        print(f"✅ ベンダーブロブは取得済み ({OUT_DIR})")
+        return
+
+    print(f"📦 {ZIP_NAME} から 2 ファイルだけ取り出す (Range リクエスト)")
+    found = locate_members()
+
+    for want, (out_name, to_lf, expect) in MEMBERS.items():
+        local_offset, comp_size, method, name = found[want]
+        raw = extract(local_offset, comp_size, method)
+        if to_lf:
+            raw = raw.replace(b"\r\n", b"\n")
+
+        got = sha256(raw)
+        if got != expect:
+            sys.exit(
+                f"🚨 {out_name} の sha256 が想定と違う\n"
+                f"   期待: {expect}\n"
+                f"   実際: {got}\n"
+                f"   配布物が更新された可能性がある。patches/ のパッチが当たるか"
+                f" 確認したうえで、このスクリプトの EXPECTED を更新すること"
+            )
+
+        (OUT_DIR / out_name).write_bytes(raw)
+        print(f"   {name} → {out_name} ({len(raw):,} バイト)")
+
+    print(f"✅ 取得完了 ({OUT_DIR})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`qmk_firmware_geonix41` で育てていた geonix41 を windmill に合流させました。
キーマップ処理は `windmill.c` 側に既に移植済みだったので、geonix41 側は
ベンダーライブラリとの配線だけになり、LEDも windmill のキー別配色に統一しています。

```
output/windmill_technik.hex     45,631
output/windmill_ymd40.hex       47,509
output/windmill_minipeg48.hex   35,829
output/windmill_geonix41.bin    67,564   ← 新規
```

## この機種だけ素のQMKではビルドできない

- ベンダーブロブ (`librdrcommon.a`) が HIDレポートの送出経路を差し替えるため、
  QMKコアに `patches/qmk-core-rdr-lib.patch` が要る
- ES32 のクロックとUSBに `patches/es32-fs026-geonix41.patch` が要る
- ブロブは単一オブジェクトなので `del_key_from_report()` などコア関数の実装まで
  持ち込まれる。パッチ側では同名定義を落としてあり、**この状態で他機種を
  ビルドすると未定義参照で落ちる**

そのため `entrypoint.sh` は **「素の3機種 → パッチ適用 → geonix41」** の順にしました。
コンテナは `--rm` の使い捨てなのでパッチを剥がす処理は要りません。

## ブロブの入手 (`scripts/fetch-vendor-blob.py`)

配布物は約1GBのQMKソース一式zipですが、必要なのは2ファイル・計97KBだけです。
zip は末尾の中央ディレクトリから各メンバの位置を引ける形式なので、HTTPの Range
リクエストで該当部分だけ抜いています。

**転送量 4.5MB・約10秒**。取得済みなら 45ms で終わります (sha256 で冪等判定)。
CIでは `actions/cache` で `vendor/` ごとキャッシュします。
再配布しないのでリポジトリには含めません (`.gitignore`)。

## windmill.c 側の変更

- 機種固有の割り込み口を weak で追加 (`windmill_board_post_init` /
  `_pre_process_record` / `_process_record` / `_led_begin`)。
  `windmill.c` が `*_kb` フックを占有しているため
- スリープ抑止は `pre_process` 側に置いた。`MY_*` のように windmill が途中で
  消費するキーでも通す必要があるため (`process_record` 末尾だと打鍵中に
  スリープしうる)
- カスタムキーコードの開始位置を `WINDMILL_KEYCODE_BASE` で動かせるようにした。
  rdr_lib が `QK_KB_0` から30個使っているので geonix41 は `QK_KB_30` から

## 確認しておいてほしい点

### 既存3機種の生成物が 20〜33バイト (hex表記) 増えます

weak フックの呼び出しを GCC が削れないためです。QMKコア自体は3機種のビルド時点では
素のままですが、`windmill.c` を共有している以上ゼロにはなりません。
気になるようなら `#ifdef` で geonix41 だけが払う形にもできます。

### `MY_O`/`MY_P` の Android 判定が変わります

旧 geonix41 は BLE3 接続で自動判定していましたが、windmill 流の
`MY_WIN`/`MY_ANDR` 明示キー (FN層・EEPROM保存) に統一しました。
他3機種と挙動がそろい、USB/2.4G でも切り替えられます。

### 実機未検証

ビルドは通っていますが、LED配色・親指シフト・無線切替は実機確認が必要です。
特に LED は「ベンダー実装 (`User_Led_Show`) → windmill配色」の順で描く設計なので、
順序が正しいかは実機でないと分かりません。

## その他ハマった点

- `vendor/` を `keyboards/` 配下に置くと `qmk lint` が「あるはずのないファイル」として
  弾くので、QMKツリーの `lib/rdr_lib/` にマウントする形にした
- Docker イメージの ARM GCC は **15.2** で、ES32 の CMSIS ヘッダ (インクルードガードの
  綴り違い) が `-Wheader-guard` に当たる。ベンダー由来なので `-Wno-error=header-guard`
  で警告に落とした
- ベンダー設定の `EECONFIG_KB_DATA_SIZE 1` を外した。QMK は これが 0 のときだけ
  `eeconfig_read_kb()` を生やすので、そのままだと windmill の設定保存が通らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)