### PR TITLE
親指Shift中の1打鍵目だけShiftが効かない問題を修正 (#18)

### DIFF
--- a/firmware/windmill.c
+++ b/firmware/windmill.c
@@ -237,18 +237,37 @@ static void td_double_confirm(void) {
  * Shift時に別の記号を出すキー
  */
 
-/* Shift付きで押されたらShiftを一時抑制して shifted を、
- * そうでなければ plain を送出する (QMKのkey override相当) */
+// shifted 側が Shift 付きのキーコード (S(KC_x)) かどうか
+static bool is_shifted_keycode(uint16_t keycode) {
+    return IS_QK_MODS(keycode) && (QK_MODS_GET_MODS(keycode) & MOD_LSFT);
+}
+
+/* Shift付きで押されたら shifted を、そうでなければ plain を送出する
+ * (QMKのkey override相当)。
+ *
+ * shifted 側もShiftを要するキー (S(KC_COMM) → 「、」など) では、押されている
+ * Shiftをそのまま使い、修飾の付け外しを一切しない。以前は必ず
+ *   実Shiftを外す → shifted のweak Shiftを付ける → 外す
+ * としていたので、ホストには「右Shiftを離して左Shiftを押す」レポートが1本
+ * 挟まっていた。この入れ替えが起きるのは親指Shiftを押してからの1打鍵目だけで、
+ * そこだけShiftが効かない機種があった (issue #18)。
+ *
+ * あわせて del_mods()/set_mods() をやめる。この2つは real_mods を書き換える
+ * だけでレポートを送らないため、親指Shiftを押し続けていてもホスト側では
+ * 文字ごとにShiftが離れた状態になっていた。 */
 static bool process_shift_pair(uint16_t plain, uint16_t shifted, keyrecord_t *record) {
-    if (record->event.pressed) {
-        const uint8_t mods = get_mods();
-        if (mods & MOD_MASK_SHIFT) {
-            del_mods(MOD_MASK_SHIFT);
-            tap_code16(shifted);
-            set_mods(mods);
-        } else {
-            tap_code16(plain);
-        }
+    if (!record->event.pressed) return false;
+
+    const uint8_t shift = get_mods() & MOD_MASK_SHIFT;
+    if (!shift) {
+        tap_code16(plain);
+    } else if (is_shifted_keycode(shifted)) {
+        tap_code(QK_MODS_GET_BASIC_KEYCODE(shifted)); // 押されているShiftをそのまま使う
+    } else {
+        // shifted 側はShift無しで送る必要がある (バックスラッシュなど)
+        unregister_mods(shift);
+        tap_code16(shifted);
+        register_mods(shift);
     }
     return false;
 }


### PR DESCRIPTION
Fixes #18

## 症状

technik で、言語切り替えの直後に親指Shift + `の` を打つと `、` ではなく **`ね`** が出る。2打鍵目以降は正しく `、` になる。

```
KC_LCTL down up          : 英数レイヤーへ
KC_F    down up          : "f"
KC_LCTL down up down up  : かなレイヤーへ
KC_N down KC_K down up down up KC_N up
  → 実機 "ね、" / 期待 "、、"
```

`ね` は `KC_COMM` が Shift なしで届いたということなので、`process_shift_pair()` は Shift 分岐 (`S(KC_COMM)` 側) に正しく入っていて、**修飾だけが落ちている**。

## 原因

`み` は `RSFT_T(KC_N)` なので、押されているのは**右**Shift。ところが従来の `process_shift_pair()` は Shift 付きで押されたとき、必ず

```
実Shiftを外す → shifted 側の weak Shift を付ける → 外す
```

という手順を踏んでいた。`S(KC_COMM)` のように shifted 側も Shift を要するキーでは、この付け外しに意味がないうえ、ホストには次のレポートが並ぶ。

```
1回目: [RSFT] → [LSFT] → [LSFT + KC_COMM]   ← 右Shift解放 + 左Shift押下 が同一レポート
2回目:          [LSFT] → [LSFT + KC_COMM]   ← クリーン
```

この入れ替えが挟まるのは親指Shiftを押してからの**1打鍵目だけ**である。2打鍵目以降が `[LSFT]` から始まるのは、`set_mods()` がレポートを送らないので実Shiftがホストに再送されないため。報告の「1文字目だけ Shift が効かない」と一致する。

geonix41 で再現しないのは、firmware の送出レポート自体は同一 (ハーネスで確認済み) なので、ホスト側の HID 処理の差と考えられる。両機で報告経路に効く違いは NKRO の有無 (geonix41: on / technik: off = 6KRO ブートプロトコル)。ここは実機の HID キャプチャなしには断定できていない。

## 修正

`process_shift_pair()` を書き換えた。

- shifted 側が Shift 付きキーコードなら → **押されている Shift をそのまま使い、素のキーコードだけ送る**
- shifted 側が Shift 不要なキー (`MY_R`→`KC_BSLS` など) なら → 従来どおり外して戻すが、`del_mods()`/`set_mods()` ではなく **`unregister_mods()`/`register_mods()`** を使う

後者は v2 実装からの退行の修正でもある。`del_mods()`/`set_mods()` は `real_mods` を書き換えるだけでレポートを送らないため、親指Shiftを押し続けていてもホスト側では文字ごとに Shift が離れた状態になっていた。

修正後のレポート列:

```
1回目: [RSFT] → [RSFT + KC_COMM] → [RSFT]
2回目:          [RSFT + KC_COMM] → [RSFT]
```

修飾の付け外しが消え、1打鍵目と2打鍵目が同一になる。

## 検証

QMK 0.33.11 のユニットテスト基盤に `firmware/windmill.c` と technik のキーマップを載せて、送出される HID レポートを直接確認した。

- 報告手順を 1:1 でなぞったケース
- 全 shift pair パターン: `S(KC_COMM)` / `S(KC_LBRC)` (Shift 要)、`KC_BSLS` / `KC_MINS` / `KC_RBRC` (Shift 外す)、Shift なし

いずれも意図どおりのレポートになることを確認済み。テストハーネス自体は別PRで出す。

実機 (technik) での確認はまだ。焼いて `、、` になるか見てほしい。

---

> [!NOTE]
> `み` + `ら` が `゛` になる件は別問題の可能性が残っている。JIS かな配列では `Shift+@` (`S(KC_LBRC)`) に割り当てがなく `゛` のままで、`「` は `Shift+[` (`S(KC_RBRC)`)。この修正後も `゛` のままなら、`MY_O`/`MY_P` の Windows 側マッピングを見直す話になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xshia4ENuQZfFwUU7kZaD5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xshia4ENuQZfFwUU7kZaD5)_