### PR TITLE
キー処理のユニットテストを追加 (#20 の再送)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,15 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Run tests
+        run: bash scripts/test.sh
+
   build:
     name: Build firmware
     runs-on: ubuntu-latest

--- a/docs/build.md
+++ b/docs/build.md
@@ -16,3 +16,13 @@ $ bash scripts/build.sh
 ```
 
 `output`ディレクトリ内にファームウェアが作成されます。
+
+## テスト
+
+キー処理のユニットテストがあります。同じくDockerだけあれば動きます。
+
+```bash
+$ bash scripts/test.sh
+```
+
+詳細は [tests/readme.md](../tests/readme.md) を参照してください。

--- a/patches/qmk-test-harness.patch
+++ b/patches/qmk-test-harness.patch
@@ -1,0 +1,27 @@
+diff --git a/tests/test_common/matrix.c b/tests/test_common/matrix.c
+index 1d994027..2062aa8b 100644
+--- a/tests/test_common/matrix.c
++++ b/tests/test_common/matrix.c
+@@ -38,7 +38,8 @@ void matrix_print(void) {}
+ 
+ void matrix_init_kb(void) {}
+ 
+-void matrix_scan_kb(void) {}
++__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
++__attribute__((weak)) void matrix_scan_user(void) {}
+ 
+ void press_key(uint8_t col, uint8_t row) {
+     matrix[row] |= (matrix_row_t)1 << col;
+diff --git a/tests/test_common/test_common.h b/tests/test_common/test_common.h
+index 8b93c032..c3719f62 100644
+--- a/tests/test_common/test_common.h
++++ b/tests/test_common/test_common.h
+@@ -1,4 +1,8 @@
+ #pragma once
+ 
++#ifndef MATRIX_ROWS
+ #define MATRIX_ROWS 4
++#endif
++#ifndef MATRIX_COLS
+ #define MATRIX_COLS 10
++#endif

--- a/scripts/test-entrypoint.sh
+++ b/scripts/test-entrypoint.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+if [ ! -f /.dockerenv ]; then
+    echo '🚨  Do not run it outside a Docker container.' 1>&2
+    exit 1
+fi
+
+project=$1
+
+# QMKのテスト基盤に2箇所だけ手を入れる (patches/qmk-test-harness.patch 参照)。
+# コンテナは --rm の使い捨てなので、剥がす処理は要らない
+git apply /patches/qmk-test-harness.patch
+
+make "test:$project"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,24 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.." # move to the current dir
+dirpath="$( pwd -P )" # study the dir path
+project=windmill
+
+# build.sh と同じイメージを使う。QMKのバージョンはDockerfileのARGが正
+qmk_version=$(sed -n 's/^ARG QMK_VERSION=//p' ./scripts/Dockerfile)
+image="$project-qmk:$qmk_version"
+
+if [ -z "$(docker image ls -q "$image")" ]; then
+  docker build -t "$image" -f ./scripts/Dockerfile .
+fi
+
+# ユニットテストなので geonix41 のベンダーブロブは要らない (fetch-vendor-blob.py は走らせない)
+docker run \
+  --interactive --rm \
+  --mount type=bind,source="$dirpath/firmware",target="/qmk_firmware/keyboards/$project" \
+  --mount type=bind,source="$dirpath/tests",target="/qmk_firmware/tests/$project",readonly \
+  --mount type=bind,source="$dirpath/patches",target="/patches",readonly \
+  --mount type=bind,source="$dirpath/scripts/test-entrypoint.sh",target="/test-entrypoint.sh" \
+  --entrypoint /bin/bash \
+  "$image" /test-entrypoint.sh $project

--- a/tests/config.h
+++ b/tests/config.h
@@ -1,0 +1,28 @@
+/* Copyright 2026 Tsutomu Kawamura
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/* 実機と同じ 4x12 にする。test_common.h の既定は 4x10 で、そちらは
+ * patches/qmk-test-harness.patch で #ifndef 化してあるので先勝ちになる */
+#define MATRIX_ROWS 4
+#define MATRIX_COLS 12
+
+#include "test_common.h"
+
+// 各機種の keyboard.json / config.h と揃えること
+#define TAPPING_TERM 200
+#define HOLD_ON_OTHER_KEY_PRESS

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,0 +1,52 @@
+# ユニットテスト
+
+QMK のテスト基盤 (`make test:<name>`, gtest/gmock) に `firmware/windmill.c` を
+そのまま載せて、**ホストへ送出されるHIDレポート列**を検証する。実機もエミュレータも要らない。
+
+```bash
+$ bash scripts/test.sh
+```
+
+`scripts/build.sh` と同じ Docker イメージ (`scripts/Dockerfile` の `QMK_VERSION`) を使う。
+geonix41 のベンダーブロブは使わないので、取得は走らない。
+
+## なぜレポート列を見るのか
+
+issue #18 は「言語切り替え直後の1打鍵目だけ Shift が効かず、`、` ではなく `ね` が出る」というもので、
+原因は `process_shift_pair()` が
+
+```
+実Shiftを外す → shifted 側の weak Shift を付ける → 外す
+```
+
+と修飾を入れ替えていたことだった。ホストから見ると1打鍵目だけ
+
+```
+[RSFT]  →  [LSFT]  →  [LSFT + KC_COMM]     ← 右Shiftを離して左Shiftを押す1本が挟まる
+```
+
+となる。**送出されるキーコード自体は正しい**ので、キーコードだけ突き合わせても気づけない。
+だからこのテストは `EXPECT_REPORT` でレポートを1本ずつ固定している。
+
+## 構成
+
+| ファイル | 中身 |
+|--|--|
+| `config.h` | マトリクスサイズと tapping 設定。実機の `keyboard.json` / `config.h` と揃える |
+| `test.mk` | `firmware/windmill.c` をテストへリンクする |
+| `test_keymap.hpp` | テスト用キーマップと `WindmillTest` フィクスチャ |
+| `test_shift_pair.cpp` | 親指Shift + `process_shift_pair()` のレポート列 |
+
+`test_keymap.hpp` のキーマップは `firmware/technik/keymaps/default/keymap.c` と同じ内容。
+実機側は `LAYOUT_ortho_4x12` マクロと PROGMEM に依存していてそのままは読めないため、
+ここだけ二重管理になっている。**キー配置を変えたら両方直すこと。**
+
+## QMK 側へのパッチ
+
+`patches/qmk-test-harness.patch` で `tests/test_common/` に2箇所だけ手を入れている。
+コンテナは使い捨てなので剥がす処理はない。
+
+- `matrix.c`: `matrix_scan_kb()` を weak にして `matrix_scan_user()` を呼ぶようにする。
+  windmill.c が `matrix_scan_kb()` を実装しているため、そのままだと多重定義になる
+- `test_common.h`: `MATRIX_ROWS` / `MATRIX_COLS` を `#ifndef` で囲む。
+  既定が 4x10 なので、実機と同じ 4x12 にできない

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -1,0 +1,23 @@
+# Copyright 2026 Tsutomu Kawamura
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# firmware/ は /qmk_firmware/keyboards/windmill へ、tests/ は
+# /qmk_firmware/tests/windmill へマウントされる (scripts/test.sh 参照)。
+# テスト対象は windmill.c 本体そのもので、コピーは持たない。
+SRC   += keyboards/windmill/windmill.c
+VPATH += $(TOP_DIR)/keyboards/windmill
+
+# Bootmagic/Command は実機の挙動に関係ないので落としておく
+COMMAND_ENABLE = no

--- a/tests/test_keymap.hpp
+++ b/tests/test_keymap.hpp
@@ -1,0 +1,94 @@
+/* Copyright 2026 Tsutomu Kawamura
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* テスト用のキーマップ。firmware/technik/keymaps/default/keymap.c と同じ内容を
+ * QMK のテスト基盤 (set_keymap) に載せられる形で持つ。geonix41 / minipeg48 /
+ * ymd40 も、windmill.c が見る範囲は同じ配置なのでこれ1枚で足りる。
+ *
+ * 実機の keymap.c は LAYOUT_ortho_4x12 マクロと PROGMEM に依存していて
+ * そのままは使えないため、ここだけ二重管理になる。配置を変えたら両方直すこと。 */
+
+#pragma once
+
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+extern "C" {
+#include "windmill.h"
+}
+
+// clang-format off
+static const uint16_t windmill_keymap[LAYER_SIZE][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [LAYER_KANA] = {
+    {KC_ESC,  KC_1,         KC_2,         KC_3,        KC_4,          KC_5,           KC_6,           KC_7,          KC_8,           KC_9,       KC_0,    KC_ENT},
+    {KC_TAB,  KC_Q,         MY_W,         KC_E,        MY_R,          KC_T,           KC_Y,           MY_U,          KC_I,           MY_O,       MY_P,    MY_LBRC},
+    {KC_BSPC, MY_A,         KC_S,         KC_D,        KC_F,          KC_G,           KC_H,           KC_J,          MY_K,           MY_L,       MY_SCLN, MY_QUOT},
+    {MY_LCTL, LGUI_T(KC_Z), LALT_T(KC_X), LT(3,KC_C),  LT(2,KC_V),    LSFT_T(KC_B),   RSFT_T(KC_N),   LT(2,KC_M),    LT(3,KC_COMMA), KC_DOT,     KC_SLSH, KC_GRV},
+  },
+
+  [LAYER_ALPHA] = {
+    {KC_TRNS, KC_Q,         KC_W,         KC_E,        KC_R,          KC_T,           KC_Y,           KC_U,          KC_I,           KC_O,       KC_P,    KC_TRNS},
+    {KC_TRNS, KC_A,         KC_S,         KC_D,        KC_F,          KC_G,           KC_H,           KC_J,          KC_K,           KC_L,       KC_SCLN, KC_QUOT},
+    {KC_TRNS, KC_Z,         KC_X,         KC_C,        KC_V,          KC_B,           KC_N,           KC_M,          KC_COMM,        KC_DOT,     KC_UP,   KC_RGHT},
+    {KC_TRNS, KC_LGUI,      KC_LALT,      MO(3),       LT(2,KC_BSLS), LSFT_T(KC_SPC), LSFT_T(KC_SPC), LT(2,KC_SLSH), MO(3),          KC_APP,     KC_LEFT, KC_DOWN},
+  },
+
+  [LAYER_SYM] = {
+    {KC_TRNS, KC_1,         KC_2,         KC_3,        KC_4,          KC_5,           KC_6,           KC_7,          KC_8,           KC_9,       KC_0,    KC_TRNS},
+    {KC_TRNS, S(KC_1),      S(KC_2),      S(KC_3),     S(KC_4),       S(KC_5),        S(KC_6),        S(KC_7),       S(KC_8),        S(KC_9),    S(KC_0), KC_GRV},
+    {KC_TRNS, KC_EQL,       S(KC_EQL),    KC_MINS,     S(KC_MINS),    KC_LBRC,        KC_RBRC,        S(KC_GRV),     S(KC_LBRC),     S(KC_RBRC), KC_UP,   KC_RGHT},
+    {KC_TRNS, KC_TRNS,      KC_TRNS,      KC_TRNS,     KC_TRNS,       S(KC_BSLS),     S(KC_SLSH),     KC_TRNS,       KC_TRNS,        KC_TRNS,    KC_LEFT, KC_DOWN},
+  },
+
+  [LAYER_FN] = {
+    {MY_WIN,  KC_NO,        KC_NO,        MY_ANDR,     KC_NO,         KC_NO,          KC_NO,          KC_NO,         KC_NO,          KC_NO,      QK_BOOT, MY_DARK},
+    {KC_F1,   KC_F2,        KC_F3,        KC_F4,       KC_F5,         KC_F6,          KC_F7,          KC_F8,         KC_F9,          KC_F10,     KC_F11,  KC_F12},
+    {KC_DEL,  KC_PSCR,      KC_NO,        KC_NO,       KC_NO,         KC_BRID,        KC_BRIU,        KC_MUTE,       KC_VOLD,        KC_VOLU,    KC_UP,   KC_RGHT},
+    {KC_TRNS, KC_TRNS,      KC_TRNS,      KC_TRNS,     KC_TRNS,       KC_TRNS,        KC_TRNS,        KC_TRNS,       KC_TRNS,        KC_TRNS,    KC_LEFT, KC_DOWN},
+  },
+};
+// clang-format on
+
+/* かなレイヤー上の位置。コメントの文字は JISかな入力での出力 */
+#define POS_LCTL 3, 0  // 英数/かな
+#define POS_KO 3, 5    // こ  左親指Shift
+#define POS_MI 3, 6    // み  右親指Shift
+#define POS_NO 2, 8    // の  MY_K   Shift時 S(KC_COMM) = 、
+#define POS_RA 1, 9    // ら  MY_O   Shift時 S(KC_LBRC)
+#define POS_SU 1, 4    // す  MY_R   Shift時 KC_BSLS  (Shiftを外す必要がある)
+#define POS_HA 2, 4    // は  KC_F   英数レイヤーでは "f"
+
+class WindmillTest : public TestFixture {
+   public:
+    void set_windmill_keymap() {
+        for (uint8_t layer = 0; layer < LAYER_SIZE; ++layer)
+            for (uint8_t row = 0; row < MATRIX_ROWS; ++row)
+                for (uint8_t col = 0; col < MATRIX_COLS; ++col)
+                    add_key(KeymapKey(layer, col, row, windmill_keymap[layer][row][col]));
+    }
+
+    KeymapKey key(uint8_t row, uint8_t col) {
+        return KeymapKey(LAYER_KANA, col, row, windmill_keymap[LAYER_KANA][row][col]);
+    }
+
+    // 押しっぱなしのキーが無い、落ち着いた状態にする
+    void settle() {
+        idle_for(TD_DTAP_TERM_MS + TAPPING_TERM);
+    }
+
+    static constexpr unsigned TD_DTAP_TERM_MS = 180; // windmill.c の TD_DTAP_TERM
+};

--- a/tests/test_shift_pair.cpp
+++ b/tests/test_shift_pair.cpp
@@ -1,0 +1,174 @@
+/* Copyright 2026 Tsutomu Kawamura
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* 親指Shift + process_shift_pair() のHIDレポートを検証する。
+ *
+ * ここで見たいのは「どの文字が出たか」ではなく「どんなレポート列が出たか」。
+ * issue #18 は修飾の付け外しが1本余計なレポートを挟むのが原因で、キーコード
+ * だけ見ていると気づけなかった。 */
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.hpp"
+#include "action_layer.h"
+#include "action_util.h"
+#include "test_keymap.hpp"
+
+using testing::_;
+using testing::AnyNumber;
+using testing::InSequence;
+
+class ShiftPair : public WindmillTest {};
+
+/* MY_LCTL 1回タップで英数、2回タップでかな。
+ * 1回タップは TD_DTAP_TERM 経過後に matrix_scan_kb() が確定させる。 */
+static void tap_lctl(WindmillTest* f, int times) {
+    auto lctl = f->key(POS_LCTL);
+    for (int i = 0; i < times; ++i) {
+        lctl.press();
+        f->run_one_scan_loop();
+        f->idle_for(120);
+        lctl.release();
+        f->run_one_scan_loop();
+        if (i + 1 < times) f->idle_for(60); // TD_DTAP_TERM 未満
+    }
+    f->settle();
+}
+
+/* issue #18 の再現手順そのもの。
+ *
+ *   MY_LCTL タップ         : 英数へ
+ *   は の位置 (英数では f) : 1文字入力
+ *   MY_LCTL ダブルタップ   : かなへ
+ *   み を押しながら の を2回
+ *
+ * 修正前は1打鍵目だけ [RSFT] -> [LSFT] -> [LSFT + KC_COMM] と、右Shiftを離して
+ * 左Shiftを押し直すレポートが挟まっていた。technik ではその1文字だけ Shift が
+ * 無視されて「、」ではなく「ね」になっていた。 */
+TEST_F(ShiftPair, thumb_shift_keeps_held_shift_on_first_keypress) {
+    TestDriver driver;
+    set_windmill_keymap();
+
+    // 英数へ切り替えて1文字打ち、かなへ戻す。ここのレポートは問わない
+    EXPECT_ANY_REPORT(driver).Times(AnyNumber());
+    tap_lctl(this, 1);
+    tap_key(key(POS_HA), 120);
+    settle();
+    tap_lctl(this, 2);
+    VERIFY_AND_CLEAR(driver);
+
+    auto mi = key(POS_MI);
+    auto no = key(POS_NO);
+
+    {
+        InSequence s;
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT));                // み ホールド確定
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT, KC_COMMA));      // 1打鍵目
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT));
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT, KC_COMMA));      // 2打鍵目
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT));
+        EXPECT_EMPTY_REPORT(driver);                            // み 解放
+    }
+
+    mi.press();
+    run_one_scan_loop();
+    idle_for(150);
+    tap_key(no, 120);
+    idle_for(120);
+    tap_key(no, 120);
+    idle_for(120);
+    mi.release();
+    run_one_scan_loop();
+    idle_for(120);
+    VERIFY_AND_CLEAR(driver);
+}
+
+// Shiftなしなら素のキーコードが出る
+TEST_F(ShiftPair, without_shift_sends_plain_keycode) {
+    TestDriver driver;
+    set_windmill_keymap();
+    settle();
+
+    {
+        InSequence s;
+        EXPECT_REPORT(driver, (KC_K));
+        EXPECT_EMPTY_REPORT(driver);
+    }
+    tap_key(key(POS_NO), 120);
+    idle_for(120);
+    VERIFY_AND_CLEAR(driver);
+}
+
+/* shifted 側が Shift 付きキーコードなら、押されている Shift をそのまま使う。
+ * 修飾の付け外しレポートが挟まらないこと。 */
+TEST_F(ShiftPair, shifted_pair_reuses_held_shift) {
+    TestDriver driver;
+    set_windmill_keymap();
+    settle();
+
+    auto mi = key(POS_MI);
+    auto ra = key(POS_RA); // MY_O -> S(KC_LBRC)
+
+    {
+        InSequence s;
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT));
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT, KC_LEFT_BRACKET));
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT));
+        EXPECT_EMPTY_REPORT(driver);
+    }
+
+    mi.press();
+    run_one_scan_loop();
+    idle_for(150);
+    tap_key(ra, 120);
+    idle_for(120);
+    mi.release();
+    run_one_scan_loop();
+    idle_for(120);
+    VERIFY_AND_CLEAR(driver);
+}
+
+/* shifted 側が Shift 不要なキー (MY_R -> バックスラッシュ) では、いったん
+ * Shift を外して戻す。del_mods()/set_mods() はレポートを送らないので、
+ * ここは register 系でなければ戻りがホストへ伝わらない。 */
+TEST_F(ShiftPair, unshifted_pair_drops_and_restores_shift) {
+    TestDriver driver;
+    set_windmill_keymap();
+    settle();
+
+    auto mi = key(POS_MI);
+    auto su = key(POS_SU); // MY_R -> KC_BSLS
+
+    {
+        InSequence s;
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT));
+        EXPECT_EMPTY_REPORT(driver);             // Shift を外す
+        EXPECT_REPORT(driver, (KC_BACKSLASH));
+        EXPECT_EMPTY_REPORT(driver);
+        EXPECT_REPORT(driver, (KC_RIGHT_SHIFT)); // Shift を戻す (レポートが出ること)
+        EXPECT_EMPTY_REPORT(driver);             // み 解放
+    }
+
+    mi.press();
+    run_one_scan_loop();
+    idle_for(150);
+    tap_key(su, 120);
+    idle_for(120);
+    mi.release();
+    run_one_scan_loop();
+    idle_for(120);
+    VERIFY_AND_CLEAR(driver);
+}


### PR DESCRIPTION
#20 の中身を main に入れ直すPR。コミットは #20 と同じ `ef730b6` で、内容は変わっていない。

## なぜ出し直しか

#20 の base を `claude/issue-18-investigation-y1qxz2` (#19 のブランチ) にしたまま出したのが原因。「#19 がマージされたら自動で main に向き直る」と説明したが、これは誤りだった。GitHub が base を自動で付け替えるのは **head ブランチが削除されたとき**で、#19 のブランチは残っているため付け替わらなかった。

結果、#20 は #19 のブランチにマージされただけで main には入っていない。

- `firmware/windmill.c` の修正 (#19) → main に入っている
- テストハーネス (#20) → main に入っていない

`origin/main` に対して衝突なくマージできることは確認済み。

## 中身 (#20 と同じ)

QMK のテスト基盤 (`make test:<name>`, gtest/gmock) に `firmware/windmill.c` をそのまま載せて、**ホストへ送出されるHIDレポート列**を検証する。

```bash
$ bash scripts/test.sh
```

`tests/test_shift_pair.cpp` に4件。いずれも #19 の修正前の `windmill.c` では落ちる。

| ケース | 内容 |
|--|--|
| `thumb_shift_keeps_held_shift_on_first_keypress` | issue #18 の再現手順。1打鍵目と2打鍵目が同一のレポート列になること |
| `without_shift_sends_plain_keycode` | Shiftなしなら素のキーコードが出ること |
| `shifted_pair_reuses_held_shift` | shifted 側がShift付きなら、押されているShiftをそのまま使い、付け外しレポートが挟まらないこと |
| `unshifted_pair_drops_and_restores_shift` | shifted 側がShift不要 (`MY_R`→バックスラッシュ) なら外して戻し、戻りがレポートに出ること |

`patches/qmk-test-harness.patch` で QMK のテスト基盤に2箇所だけ手を入れる (`matrix_scan_kb()` の多重定義回避と、マトリクスサイズを実機と同じ 4x12 にするため)。CI には `test` ジョブを追加。

詳細は `tests/readme.md` と #20 の説明を参照。

## マージ後に

`claude/issue-18-investigation-y1qxz2` と `claude/issue-18-test-harness-y1qxz2` はどちらも用済みなので削除してよい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xshia4ENuQZfFwUU7kZaD5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xshia4ENuQZfFwUU7kZaD5)_