### PR TITLE
余った Create PR リンクをコメントから剥がす

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,6 +70,40 @@ jobs:
             --max-turns 60
             --allowedTools "Bash(bash scripts/test.sh),mcp__github__create_pull_request"
 
+      # action の後処理は「PRがもう在るか」をAPIで確かめず、コメント本文に
+      # compare URL が無ければ「Create PR」リンクを足す。PRを作らせている今の
+      # 使い方だと必ず余る。しかもURLの抜き出しに使う正規表現が
+      # `[Claude Code](https://claude.ai/code)` のカッコで切れてリンクが壊れる。
+      # 直せるのは向こうなので、こちらは出てきたぶんを剥がす
+      - name: Tidy up the tracking comment
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE/comments" --paginate \
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | test("Create PR ➔")))] | last | .id // empty' \
+            | tail -n1)
+          if [ -z "$id" ]; then
+            echo "剥がすリンクは無し"
+            exit 0
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" --jq .body > "$RUNNER_TEMP/body.md"
+          python3 - "$RUNNER_TEMP/body.md" "$RUNNER_TEMP/patch.json" <<'PY'
+          import json, re, sys
+
+          src, dst = sys.argv[1], sys.argv[2]
+          with open(src, encoding="utf-8") as f:
+              body = f.read()
+          # ヘッダー行の末尾に付く ` • [Create PR ➔](...)` だけを落とす
+          body = re.sub(r" • \[Create PR ➔\]\(.*$", "", body, flags=re.M)
+          with open(dst, "w", encoding="utf-8") as f:
+              json.dump({"body": body}, f)
+          PY
+          gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" --input "$RUNNER_TEMP/patch.json" --silent
+          echo "コメント $id から Create PR リンクを剥がした"
+
   # 既存の issue / PR で @claude と呼んだときの受け答え。
   # 追加指示やレビュー対応はこちらに乗る
   mentioned:


### PR DESCRIPTION
issue #23 の2回目の実行でPRまで作れたが、tracking コメントのヘッダーに
不要な「Create PR ➔」が残り、そのリンクが壊れて生のURLが露出していた。

```
… • ``[Create PR ➔](https://github.com/cognitom/windmill/compare/main...claude/issue-23-20260802-1128?quick_pull=1&title=Issue%20%2323%3A%20Changes%20from%20Claude&body=…%5BClaude%20Code%5D(https%3A%2F%2Fclaude.ai%2Fcode)``
```

## 原因

どちらも `anthropics/claude-code-action` 側の作りによるもので、設定では消せない。

**リンクが残るのは、PRの有無を確認していないから。**
`update-comment-link.ts` は「PRがもう在るか」をAPIで調べず、**コメント本文に
compare URL が含まれているか**だけを見る。Claude が実際のPR (`/pull/26`) へ
リンクすると compare URL は本文に無いので「まだPRが無い」と判定され、汎用の
リンクが足される。タイトルが `Issue #23: Changes from Claude` という
素っ気ない既定値なのも同じ理由。

**リンクが壊れるのは正規表現の取りこぼし。**
`comment-logic.ts` がURLを抜き出すのに `\(([^)]+)\)` を使っているが、
PR本文には `[Claude Code](https://claude.ai/code)` が入っていて、
`encodeURIComponent` は `(` `)` をエンコードしない。最初の `)` で切られて
閉じカッコが1つ足りないURLになり、Markdownのリンクとして成立しなくなる。

## 直したこと

`labeled` ジョブの最後に後片付けのステップを追加した。tracking コメントの
**ヘッダー行の末尾に付いた ` • [Create PR ➔](...)` だけ**を落とす。
本文 (チェックリストや説明) には触らない。

- `View job` とブランチへのリンクは残る
- `if: always()` なので Claude 側が失敗した回でも剥がす
- 剥がす対象が無ければ何もせず終了する。コメントの書式が変わっても
  ジョブは落ちない

実際に壊れたコメントを入力にして手元で流し、意図どおり1行だけ縮むことを
確認した。

## 位置づけ

これはバグの後始末であって修正ではない。upstream が直せば不要になる。
2点とも報告する価値はある。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBLh4YDcNw4Go8SbDKntQ8)_