### PR TITLE
手強い issue で Opus 5 に切り替えられるようにする

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,13 +15,15 @@ on:
 permissions: {}
 
 jobs:
-  # 本番ルート。調査 → 実装 → テスト → PR まで通しでやらせる
+  # 本番ルート。調査 → 実装 → テスト → PR まで通しでやらせる。
+  # 手強い issue は claude-opus ラベルのほうを付けてモデルを上げる
   labeled:
     name: Work on labeled issue
     # 起動できるのはリポジトリの持ち主だけ (CLAUDE_USER で上書きできる)。
     # 他人のラベル付けやコメントでは動かないので、使う枠は自分の操作ぶんに収まる
     if: >-
-      github.event.label.name == 'claude' &&
+      (github.event.label.name == 'claude' ||
+       github.event.label.name == 'claude-opus') &&
       github.actor == (vars.CLAUDE_USER || github.repository_owner)
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -66,7 +68,7 @@ jobs:
             キー配置の好みや設計方針など、判断が割れそうなところは勝手に決めない。
             issue にコメントで質問して、そこで止まること。
           claude_args: |
-            --model claude-sonnet-5
+            --model ${{ github.event.label.name == 'claude-opus' && 'claude-opus-5' || 'claude-sonnet-5' }}
             --max-turns 60
             --allowedTools "Bash(bash scripts/test.sh),mcp__github__create_pull_request"
 
@@ -140,6 +142,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-sonnet-5
+            --model ${{ contains(github.event.comment.body, '@claude opus') && 'claude-opus-5' || 'claude-sonnet-5' }}
             --max-turns 60
             --allowedTools "Bash(bash scripts/test.sh),mcp__github__create_pull_request"

--- a/docs/claude-bot.md
+++ b/docs/claude-bot.md
@@ -8,7 +8,9 @@ issue に `claude` ラベルを付けると、GitHub Actions 上で Claude が�
 | きっかけ | 動き |
 |--|--|
 | issue に `claude` ラベルを付ける | issue に進捗コメントを立てて実装し、PRを出す |
+| issue に `claude-opus` ラベルを付ける | 同上。手強い issue 用にモデルを Opus 5 へ上げる |
 | issue / PR のコメントで `@claude` と書く | その場で返事をする。追加指示やレビュー対応はこちら |
+| コメントで `@claude opus` と書く | 同上。こちらもモデルが Opus 5 になる |
 
 コミットもPRもコメントも **`claude[bot]`** (Claude GitHub App) 名義になる。
 `cognitom` 名義では書き込まれない。
@@ -32,7 +34,8 @@ PRができると `Build` ワークフローが走り、4機種ぶんのコン�
 2. **トークンを置く。** 手元で `claude setup-token` を実行し、出てきたトークンを
    Settings → Secrets and variables → Actions → Secrets に
    `CLAUDE_CODE_OAUTH_TOKEN` として登録する
-3. **ラベルを作る。** Issues → Labels → New label で `claude` を作る
+3. **ラベルを作る。** Issues → Labels → New label で `claude` と
+   `claude-opus` を作る
 
 ボット用のアカウントは要らない。トークンは
 **Claude Code のサブスクリプション (Pro / Max) の枠**で動く。
@@ -40,6 +43,8 @@ PRができると `Build` ワークフローが走り、4機種ぶんのコン�
 ## 使い方
 
 issue を書いて `claude` ラベルを付ける。あとは進捗コメントとPRを待つ。
+既定は Sonnet 5 で、うまく捌けなかった issue は `claude-opus` のほうを付け直す
+(**両方付けると2回走る**ので、どちらか一方にする)。
 やることが曖昧だったり、キー配列の方針など好みが割れる判断が要るときは、
 Claude は勝手に決めずに issue へ質問をコメントして止まる。
 そこに答えるか、PRに `@claude` で追加指示を出せば続きをやる。
@@ -77,7 +82,8 @@ windmill は public なので無料枠だが、非公開だと月あたりの無
 
 - **枠は対話セッションと共有になる。** CIでの実行が、手元で Claude Code を
   使うときと同じ枠を消費する。ジョブは60分で打ち切る。
-  モデルとターン数は `claude_args` で変える
+  ターン数は `claude_args` で変える
+- **Opus は枠の減りが速い。** 常用せず、Sonnet で捌けなかった issue に絞る
 - **トークンには期限がある** (発行から約1年)。切れると静かに動かなくなるので、
   動かなくなったらまず `claude setup-token` を取り直す
 - **第三者のPRでは `@claude` と書かない。** 向こうのコードをチェックアウトして


### PR DESCRIPTION
Sonnet 5 で捌けなかった issue のために、モデルを上げる手段を用意する。
既定は Sonnet 5 のまま変えない。

## 切り替え方

| 操作 | モデル |
|--|--|
| `claude` ラベル | Sonnet 5 |
| `claude-opus` ラベル | Opus 5 |
| コメントで `@claude` | Sonnet 5 |
| コメントで `@claude opus` | Opus 5 |

起動がラベルなので、モデルの指定もラベルで揃えたほうが操作が一貫する。
捌けなかった issue は `claude` を外して `claude-opus` を付け直すだけ。

## 実装

ジョブは増やさず、`--model` を式で出し分ける。

```yaml
--model ${{ github.event.label.name == 'claude-opus' && 'claude-opus-5' || 'claude-sonnet-5' }}
```

コメント側も同じ形で `@claude opus` を拾う。`@claude` を含んでいるので
起動条件はそのまま通り、モデルだけ変わる。

## 注意

**両方のラベルを付けると2回走る。** `labeled` イベントがラベルごとに発火し、
concurrency は同じ issue でも走行中のジョブを潰さない設定にしてあるため。
どちらか一方にすること。`docs/claude-bot.md` にも書いた。

Opus は枠の減りが速いので常用は避ける、という一行も注意に足してある。

## マージ後に必要な設定

Issues → Labels → New label で `claude-opus` を作る。これが無いと付けられない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBLh4YDcNw4Go8SbDKntQ8)_