### PR TITLE
lint をビルドから切り出して単体で走らせられるようにする

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,23 +54,21 @@ jobs:
 
             1. まず CLAUDE.md を読む。このリポジトリの構成と守ってほしいことが書いてある
             2. issue の本文とコメントを読み、関連するコードとドキュメントを調べる
-            3. 実装したら `bash scripts/test.sh` でユニットテストを通す。
+            3. 実装したら `bash scripts/lint.sh` と `bash scripts/test.sh` を通す。
                Dockerイメージのビルドから走るので数分かかる。落ちたまま出さないこと
             4. ブランチへコミットする
             5. **`mcp__github__create_pull_request` を呼んでPRを作る。**
                action の既定の案内は「PR作成用のリンクを出す」で止まるが、
                それでは終わりにしない。本文には issue への参照を入れる
-            6. やったことを issue のコメントに返す
-
-            ファームウェアのビルド (`scripts/build.sh`) はこの場で走らせなくてよい。
-            PRを作れば Build ワークフローが4機種ぶんコンパイルする。
+            6. やったことを issue のコメントに返す。ただし、PRに書いたことは
+               そちらに書くので、issue には「PRを作った」だけでよい
 
             キー配置の好みや設計方針など、判断が割れそうなところは勝手に決めない。
             issue にコメントで質問して、そこで止まること。
           claude_args: |
             --model ${{ github.event.label.name == 'claude-opus' && 'claude-opus-5' || 'claude-sonnet-5' }}
             --max-turns 60
-            --allowedTools "Bash(bash scripts/test.sh),mcp__github__create_pull_request"
+            --allowedTools "Bash(bash scripts/lint.sh),Bash(bash scripts/test.sh),mcp__github__create_pull_request"
 
       # action の後処理は「PRがもう在るか」をAPIで確かめず、コメント本文に
       # compare URL が無ければ「Create PR」リンクを足す。PRを作らせている今の
@@ -144,4 +142,4 @@ jobs:
           claude_args: |
             --model ${{ contains(github.event.comment.body, '@claude opus') && 'claude-opus-5' || 'claude-sonnet-5' }}
             --max-turns 60
-            --allowedTools "Bash(bash scripts/test.sh),mcp__github__create_pull_request"
+            --allowedTools "Bash(bash scripts/lint.sh),Bash(bash scripts/test.sh),mcp__github__create_pull_request"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,13 @@ permissions:
 
 jobs:
   test:
-    name: Unit tests
+    name: Lint & unit tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      # test.sh と同じイメージを使うので、先に済ませても待ちは増えない
+      - name: Run lint
+        run: bash scripts/lint.sh
       - name: Run tests
         run: bash scripts/test.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ minipeg48 / geonix41 の4つで、**キー処理の本体は `firmware/windmill.
 |--|--|
 | `firmware/windmill.c` `firmware/windmill.h` | 全機種共通のキー処理。レイヤー、Shift出し分け、親指Shift、LED |
 | `firmware/<機種>/` | `keyboard.json`, `rules.mk`, `keymaps/default/keymap.c` |
-| `scripts/` | Docker越しのビルド (`build.sh`) とテスト (`test.sh`)、リリース (`release.sh`) |
+| `scripts/` | Docker越しのlint (`lint.sh`) とテスト (`test.sh`)、ビルド (`build.sh`)、リリース (`release.sh`) |
 | `patches/` | QMK本体へ当てるパッチ。コンテナ内でのみ使う |
 | `tests/` | QMKのテスト基盤に載せたユニットテスト。詳細は `tests/readme.md` |
 | `docs/` | 導入方法、ビルド手順 |
@@ -19,19 +19,31 @@ minipeg48 / geonix41 の4つで、**キー処理の本体は `firmware/windmill.
 `output/` と `vendor/` は生成物なのでコミットしない (`.gitignore` 済み)。
 `vendor/` は geonix41 のベンダー配布物で、`scripts/fetch-vendor-blob.py` が取ってくる。
 
-## ビルドとテスト
+## lintとテストとビルド
 
-どちらも Docker が要る。QMKのバージョンは `scripts/Dockerfile` の `ARG QMK_VERSION` が正。
+どれも Docker が要る。QMKのバージョンは `scripts/Dockerfile` の `ARG QMK_VERSION` が正。
 
 ```bash
+bash scripts/lint.sh    # keyboard.json の静的チェック。イメージが在れば数秒
 bash scripts/test.sh    # ユニットテスト。イメージのビルドから走ると数分かかる
-bash scripts/build.sh   # 4機種ぶんのファームウェアを output/ に出す
+bash scripts/build.sh   # 4機種ぶんのファームウェアを output/ に出す。数分かかる
 ```
 
-コードを触ったら最低限 `scripts/test.sh` は通す。PRを出せば Test ワークフロー
-(`.github/workflows/test.yml`) が同じユニットテストを走らせる。4機種ぶんの
-コンパイルはタグを打ったときの Release ワークフローでしか走らないので、
-`firmware/` を触ったときは手元で `scripts/build.sh` も通しておく。
+**コードを触ったら `scripts/lint.sh` と `scripts/test.sh` を通す。`scripts/build.sh`
+は時間がかかるので普段は走らせなくてよい。** 4機種ぶんのコンパイルはタグを打った
+ときの Release ワークフローが持つ。PRを出せば Test ワークフロー
+(`.github/workflows/test.yml`) が lint とユニットテストを走らせる。
+
+ただし手元の2つが見る範囲は限られる。ここに引っかからない変更もある。
+
+- lint (`qmk lint --strict`) が読むのは `keyboard.json` とレイアウト定義だけ。
+  Cのコードは1行も見ない
+- テストは `firmware/windmill.c` をホスト向けにコンパイルして動かす。
+  機種ごとの `keymaps/default/keymap.c` と `rules.mk` は通らない
+  (テスト側は `tests/test_keymap.hpp` を使う)
+
+だから **`keymap.c` や `rules.mk` を触ったときは `scripts/build.sh` も通しておく**。
+`firmware/windmill.c` だけの変更なら lint とテストで足りる。
 
 ## リリース
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -17,12 +17,16 @@ $ bash scripts/build.sh
 
 `output`ディレクトリ内にファームウェアが作成されます。
 
-## テスト
+## lintとテスト
 
 キー処理のユニットテストがあります。同じくDockerだけあれば動きます。
 
 ```bash
-$ bash scripts/test.sh
+$ bash scripts/lint.sh   # keyboard.json の静的チェック。数秒で終わる
+$ bash scripts/test.sh   # ユニットテスト
 ```
+
+`lint.sh` は `build.sh` の中でも走っているものと同じで、ファームウェアの
+コンパイルまではしません。手早く確かめたいときに使えます。
 
 詳細は [tests/readme.md](../tests/readme.md) を参照してください。

--- a/docs/claude-bot.md
+++ b/docs/claude-bot.md
@@ -65,8 +65,8 @@ Claude は勝手に決めずに issue へ質問をコメントして止まる。
 持ち主の判定も `github.repository_owner` を見ているだけなので設定は要らない。
 移すときに直すのはこの2つ。
 
-- **`claude_args` の `--allowedTools`。** windmill では
-  `Bash(bash scripts/test.sh)` しか許していない。移った先のテストコマンドに変える
+- **`claude_args` の `--allowedTools`。** windmill では `Bash(bash scripts/lint.sh)`
+  と `Bash(bash scripts/test.sh)` しか許していない。移った先のコマンドに変える
 - **`prompt` の中身。** ビルドとテストの手順が windmill 固有
 
 移した先ごとに、App のインストール・Secrets・`claude` ラベルの3つは要る
@@ -96,5 +96,5 @@ windmill は public なので無料枠だが、非公開だと月あたりの無
 - **ワークフローはデフォルトブランチに入るまで動かない。** App のトークンは
   「そのワークフローがデフォルトブランチに存在するか」を見て発行されるので、
   ブランチに置いただけの状態では起動しない (`workflow_not_found_on_default_branch`)
-- ユニットテストはワークフローの中で走らせるが、`scripts/build.sh` は走らせない。
-  ビルドの確認はPR側の `Build` ワークフローに任せている
+- lint とユニットテストはワークフローの中で走らせるが、`scripts/build.sh` は
+  走らせない。4機種ぶんのコンパイルはタグを打ったときの Release ワークフローが持つ

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,5 +26,6 @@ docker run \
   --mount type=bind,source="$dirpath/vendor",target="/qmk_firmware/lib/rdr_lib",readonly \
   --mount type=bind,source="$dirpath/output",target="/output" \
   --mount type=bind,source="$dirpath/scripts/entrypoint.sh",target="/entrypoint.sh" \
+  --mount type=bind,source="$dirpath/scripts/lint-entrypoint.sh",target="/lint-entrypoint.sh",readonly \
   --entrypoint /bin/bash \
   "$image" /entrypoint.sh $project

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,9 +9,11 @@ fi
 host_uid=$(ls -n "$0" | awk '{print $3}') # study who my owner is
 host_gid=$(ls -n "$0" | awk '{print $4}') # study what I belong to
 
+# lint は scripts/lint.sh と同じものを使う。単体でも走らせられるようにしてある
+bash /lint-entrypoint.sh windmill
+
 # 素のQMKで通る機種。geonix41 より先にビルドすること (下のコメント参照)
 for keyboard in technik ymd40 minipeg48; do
-  qmk lint -kb "windmill/$keyboard" -km default --strict
   make "windmill/$keyboard:default"
   mv "windmill_${keyboard}_default.hex" "/output/windmill_${keyboard}.hex"
 done
@@ -28,19 +30,6 @@ done
 echo '--- applying vendor patches (QMK core is no longer pristine from here) ---'
 git apply /patches/qmk-core-rdr-lib.patch
 git -C lib/chibios-contrib apply /patches/es32-fs026-geonix41.patch
-
-# geonix41 の lint は debounce の指摘1件だけ既知の誤検知として見逃す。
-# (消すと起動時の待ちが変わる。firmware/geonix41/readme.md 参照)
-# それ以外の指摘が出たらちゃんと落とす。
-lint_out=$(qmk lint -kb "windmill/geonix41" -km default --strict 2>&1 || true)
-echo "$lint_out"
-# ☒ の行から、既知の1件と最後のまとめ行を除いて、まだ残るものがあれば落とす
-if echo "$lint_out" | grep '☒' \
-     | grep -v 'duplicates default value of "5"' \
-     | grep -qv 'Lint check failed for'; then
-  echo '🚨 geonix41 の lint に既知以外の指摘がある' 1>&2
-  exit 1
-fi
 
 make "windmill/geonix41:default"
 mv "windmill_geonix41_default.bin" "/output/windmill_geonix41.bin"

--- a/scripts/lint-entrypoint.sh
+++ b/scripts/lint-entrypoint.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+if [ ! -f /.dockerenv ]; then
+    echo '🚨  Do not run it outside a Docker container.' 1>&2
+    exit 1
+fi
+
+project=$1
+
+# ビルドの前段としても使うので、ここは lint だけに徹すること (entrypoint.sh から呼ぶ)
+for keyboard in technik ymd40 minipeg48; do
+  qmk lint -kb "$project/$keyboard" -km default --strict
+done
+
+# geonix41 の lint は debounce の指摘1件だけ既知の誤検知として見逃す。
+# (消すと起動時の待ちが変わる。firmware/geonix41/readme.md 参照)
+# それ以外の指摘が出たらちゃんと落とす。
+lint_out=$(qmk lint -kb "$project/geonix41" -km default --strict 2>&1 || true)
+echo "$lint_out"
+# ☒ の行から、既知の1件と最後のまとめ行を除いて、まだ残るものがあれば落とす
+if echo "$lint_out" | grep '☒' \
+     | grep -v 'duplicates default value of "5"' \
+     | grep -qv 'Lint check failed for'; then
+  echo '🚨 geonix41 の lint に既知以外の指摘がある' 1>&2
+  exit 1
+fi
+echo 'Ψ geonix41 は既知の1件だけなので通過とみなす'

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.." # move to the current dir
+dirpath="$( pwd -P )" # study the dir path
+project=windmill
+
+# build.sh と同じイメージを使う。QMKのバージョンはDockerfileのARGが正
+qmk_version=$(sed -n 's/^ARG QMK_VERSION=//p' ./scripts/Dockerfile)
+image="$project-qmk:$qmk_version"
+
+if [ -z "$(docker image ls -q "$image")" ]; then
+  docker build -t "$image" -f ./scripts/Dockerfile .
+fi
+
+# lint は keyboard.json とレイアウト定義しか見ないので、
+# geonix41 のベンダーブロブもコアへのパッチも要らない
+docker run \
+  --interactive --rm \
+  --mount type=bind,source="$dirpath/firmware",target="/qmk_firmware/keyboards/$project",readonly \
+  --mount type=bind,source="$dirpath/scripts/lint-entrypoint.sh",target="/lint-entrypoint.sh",readonly \
+  --entrypoint /bin/bash \
+  "$image" /lint-entrypoint.sh $project


### PR DESCRIPTION
これまで `qmk lint` はファームウェアのビルドの前段としてしか走らず、`keyboard.json` を直しただけのときも4機種ぶんのコンパイルを待つ必要がありました。lint を取り出して、手元でもCIでも単体で走らせられるようにします。

## 変更

- `scripts/lint-entrypoint.sh` (新規) — コンテナ内の lint 本体。4機種ぶんの `qmk lint --strict` と、geonix41 の debounce 1件を既知の誤検知として見逃す判定
- `scripts/lint.sh` (新規) — ホスト側の入口。lint は `keyboard.json` とレイアウト定義しか読まないので、geonix41 のベンダーブロブもコアへのパッチも要らず、mount は `firmware/` だけで足ります
- `scripts/entrypoint.sh` — 自前で lint していたぶんを落として `lint-entrypoint.sh` を呼ぶだけに。`scripts/build.sh` はそのファイルを mount
- `.github/workflows/test.yml` — lint ステップを追加 (ジョブ名は `Lint & unit tests`)。`test.sh` と同じイメージなので待ちは伸びません
- `.github/workflows/claude.yml` — bot の手順と `--allowedTools` に `lint.sh` を追加。あわせて issue へのコメントは「PRを作った」だけでよい、という指示に
- `CLAUDE.md` / `docs/` — 追随。手元の lint とテストが見ない範囲 (lint は C を読まない、テストは機種ごとの `keymap.c` と `rules.mk` を通らない) も書き足しました

ビルドと単体実行で同じ `lint-entrypoint.sh` が走るので、二重管理にはなりません。

## 確認したこと

- `bash scripts/lint.sh` — 4機種ぶん通過。geonix41 の既知1件の見逃しも期待どおり
- `bash scripts/build.sh` — 通過。4機種ぶんのファームウェアが `output/` に出ます。`entrypoint.sh` は `set -euo pipefail` の下で `bash /lint-entrypoint.sh` を呼ぶので、完走した時点で mount と lint は通っています
- `build.sh` と同じ mount 構成のコンテナで `lint-entrypoint.sh` を直接叩き、ビルド経路でも lint が動くことを確認

## 手元では確かめられないこと

`claude.yml` の変更はデフォルトブランチに入るまで効きません (App のトークンは、そのワークフローがデフォルトブランチに在るかを見て発行される — `docs/claude-bot.md` 参照)。**このPR上では新しい bot の設定は試せず、マージ後が初回の実地確認になります。** `test.yml` の lint ステップはこのPRのCIで走ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)